### PR TITLE
Implement sbt-native-packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,13 @@ Usage: reactive-cli [options]
 
   --help             Print this help text
 ```
+
+## Packaging
+
+This project uses [SBT Native Packager](https://github.com/sbt/sbt-native-packager) to produce release artifacts.
+
+#### deb
+`sbt clean debian:packageBin`
+
+#### rpm
+`sbt clean rpm:packageBin`

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,11 @@
 val Versions = new {
-  val sbtHeader     = "3.0.1"
-  val sbtSalaNative = "0.3.3"
-  val sbtSclariform = "1.8.0"
+  val sbtHeader         = "3.0.1"
+  val sbtNativePackager = "1.2.0"
+  val sbtSalaNative     = "0.3.3"
+  val sbtSclariform     = "1.8.0"
 }
 
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"        % Versions.sbtHeader)
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"  % Versions.sbtSalaNative)
-addSbtPlugin("org.scalariform"    % "sbt-scalariform"   % Versions.sbtSclariform)
+addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager" % Versions.sbtNativePackager)
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"          % Versions.sbtHeader)
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"    % Versions.sbtSalaNative)
+addSbtPlugin("org.scalariform"    % "sbt-scalariform"     % Versions.sbtSclariform)


### PR DESCRIPTION
Initial implementation of native packaging for RPM and deb.

The binary produced, `rp`, is installed to `/usr/share/reactive-cli/bin/rp` and symlinked to `/usr/bin/rp`.

```bash
$ sbt clean debian:packageBin && dpkg -x cli/target/cli_0.1-SNAPSHOT_all.deb /tmp/out && find /tmp/out
[info] Loading global plugins from /home/longshorej/.sbt/0.13/plugins
[info] Loading project definition from /home/longshorej/work/lightbend/reactive-cli/project/project
[info] Loading project definition from /home/longshorej/work/lightbend/reactive-cli/project
[info] Set current project to reactive-cli (in build file:/home/longshorej/work/lightbend/reactive-cli/)
[success] Total time: 0 s, completed Oct 4, 2017 6:17:57 PM
[info] Updating {file:/home/longshorej/work/lightbend/reactive-cli/}libhttpsimple-bindings...
[info] Resolving jline#jline;2.14.3 ...
[info] Done updating.
[info] Updating {file:/home/longshorej/work/lightbend/reactive-cli/}cli...
[info] Resolving jline#jline;2.14.3 ...
[info] Done updating.
[info] Compiling 2 Scala sources to /home/longshorej/work/lightbend/reactive-cli/libhttpsimple-bindings/target/scala-2.11/classes...
[info] Compiling 1 Scala source to /home/longshorej/work/lightbend/reactive-cli/cli/target/scala-2.11/classes...
[info] Linking (1250 ms)
[info] Discovered 1767 classes and 12303 methods
[info] Optimizing (1684 ms)
[info] Generating intermediate code (451 ms)
[info] Produced 49 files
[info] Compiling to native code (1072 ms)
[info] Linking native code (143 ms)
[info] Building debian package with native implementation
[info] dpkg-deb: building package 'reactive-cli' in '../cli_0.1-SNAPSHOT_all.deb'.
[success] Total time: 10 s, completed Oct 4, 2017 6:18:07 PM
/tmp/out
/tmp/out/usr
/tmp/out/usr/share
/tmp/out/usr/share/reactive-cli
/tmp/out/usr/share/reactive-cli/bin
/tmp/out/usr/share/reactive-cli/bin/rp
/tmp/out/usr/bin
/tmp/out/usr/bin/rp
-> 0

```