### PR TITLE
Build for various distros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: scala
 scala:
   - 2.11.11
+services:
+  - docker
 jdk:
   - oraclejdk8
 sudo: required
@@ -16,6 +18,5 @@ before_cache:
 before_install:
   - bash setup-travis.sh
 script:
-  - sbt test
-  - sbt cli/nativeLink
-  - LD_LIBRARY_PATH=libhttpsimple/target cli/target/scala-2.11/rp --help
+  - sbt clean test package buildAll
+  - LD_LIBRARY_PATH=libhttpsimple/target cli/target/scala-2.11/reactive-cli-out --help

--- a/README.md
+++ b/README.md
@@ -63,13 +63,23 @@ Usage: reactive-cli [options]
 
 ## Packaging
 
-This project uses [SBT Native Packager](https://github.com/sbt/sbt-native-packager) to produce release artifacts.
+This project uses a Docker-based build system that builds `.rpm` and `.deb` files inside Docker containers for each
+supported distribution. To add a distribution, add a `BuildInfo` instance in `project/BuildInfo.scala` emulating
+the ones already created.
 
-#### deb
-`sbt clean debian:packageBin`
+#### Building a single distribution package locally
 
-#### rpm
-`sbt clean rpm:packageBin`
+```sbt build ubuntu-16-04```
+
+#### Building every distribution in parallel
+
+```sbt buildAll```
+
+Once built, you can find the packages in `target/stage/<name>/output`.
+
+## Releasing
+
+Consult the _Platform Tooling Release Process_ document in Google Drive. 
 
 ## Maintenance
 

--- a/cli/build.sbt
+++ b/cli/build.sbt
@@ -1,11 +1,18 @@
 import sbt._
-
+import scala.collection.immutable.Seq
 
 // Disable GC since the CLI is a short-lived process.
 nativeGC := "none"
 
-nativeLinkingOptions := Seq(
-  "-lcurl",
-  "-L", (baseDirectory.value / ".." / "libhttpsimple" / "target").toPath.toAbsolutePath.toString
-) ++ sys.props.get("nativeLinkingOptions").fold(Seq.empty[String])(_.split(" "))
+nativeLinkingOptions := {
+  val dynamicLinkerOptions =
+    Properties
+      .dynamicLinker
+      .toVector
+      .map(dl => s"-Wl,--dynamic-linker=$dl")
 
+  dynamicLinkerOptions ++ Seq(
+    "-lcurl",
+    "-L", (baseDirectory.value / ".." / "libhttpsimple" / "target").toPath.toAbsolutePath.toString
+  ) ++ sys.props.get("nativeLinkingOptions").fold(Seq.empty[String])(_.split(" ").toVector)
+}

--- a/project/AdditionalIO.scala
+++ b/project/AdditionalIO.scala
@@ -1,0 +1,17 @@
+import sbt._
+
+object AdditionalIO {
+  def setExecutable(file: File): Unit = assert(file.setExecutable(true), s"Marking $file executable failed")
+
+  def runProcess(args: String*): Unit = {
+    val code = args.!
+
+    assert(code == 0, s"Executing $args yielded $code, expected 0")
+  }
+
+  def runProcessCwd(cwd: File, args: String*): Unit = {
+    val code = Process(args, cwd).!
+
+    assert(code == 0, s"Executing $args yielded $code, expected 0")
+  }
+}

--- a/project/BintrayExt.scala
+++ b/project/BintrayExt.scala
@@ -1,0 +1,64 @@
+package bintray
+
+import dispatch._, Defaults._
+import sbt.{ File, Logger }
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object RpmBuildTarget {
+  def normalizeVersion(version: String): String =
+    version.replaceAll("-", ".")
+}
+
+/**
+ * sbt-bintray doesn't have implementations for rpm and deb uploading so
+ * this implements the functionality in the most straight-forward way.
+ *
+ * We still use the plugin so that we can read credentials so from a user's
+ * perspective (for publishing) it behaves in a similar manner.
+ */
+object BintrayExt {
+  def publishDeb(file: File, distributions: Seq[String], components: String, architecture: String, version: String, bintrayCredentialsFile: File, log: Logger): Unit = {
+    val urlString =
+      s"https://api.bintray.com/content/lightbend/deb/reactive-cli/$version/${file.getName}"
+
+    val request = withAuth(Bintray.ensuredCredentials(bintrayCredentialsFile, log))(
+      url(urlString)
+        .addHeader("X-Bintray-Debian-Distribution", distributions.mkString(","))
+        .addHeader("X-Bintray-Debian-Component", components)
+        .addHeader("X-Bintray-Debian-Architecture", architecture) <<< file)
+
+    log.info(s"Uploading ${file.getName} to $urlString")
+
+    val response = Await.result(Http(request), Duration.Inf)
+
+    val responseText = s"[${response.getStatusCode} ${response.getStatusText}] ${response.getResponseBody}"
+
+    if (response.getStatusCode >= 200 && response.getStatusCode <= 299)
+      log.info(responseText)
+    else
+      sys.error(responseText)
+  }
+
+  def publishRpm(file: File, version: String, bintrayCredentialsFile: File, log: Logger): Unit = {
+    val urlString =
+      s"https://api.bintray.com/content/lightbend/rpm/reactive-cli/${RpmBuildTarget.normalizeVersion(version)}/${file.getName}"
+
+    val request =
+      withAuth(Bintray.ensuredCredentials(bintrayCredentialsFile, log))(url(urlString) <<< file)
+
+    log.info(s"Uploading ${file.getName} to $urlString")
+
+    val response = Await.result(Http(request), Duration.Inf)
+
+    val responseText = s"[${response.getStatusCode} ${response.getStatusText}] ${response.getResponseBody}"
+
+    if (response.getStatusCode >= 200 && response.getStatusCode <= 299)
+      log.info(responseText)
+    else
+      sys.error(responseText)
+  }
+
+  private def withAuth(credentials: Option[BintrayCredentials])(request: Req) =
+    credentials.fold(request)(c => request.as_!(c.user, c.password))
+}

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -1,0 +1,288 @@
+import sbt._
+import scala.collection.immutable.Seq
+
+import AdditionalIO._
+
+object BuildInfo {
+  val Builds =
+    Seq(
+      MuslBuild.rpm("centos-6", "el6", "bash"),
+
+      BuildInfo(
+        name = "centos-7",
+        baseImage = "centos:7",
+        install = s"""|RUN \\
+                      |  curl -s http://releases.llvm.org/3.8.0/clang+llvm-3.8.0-linux-x86_64-centos6.tar.xz | tar xf - --strip-components=1 -J -C /usr/local/ && \\
+                      |  curl -s https://bintray.com/sbt/rpm/rpm > /etc/yum.repos.d/bintray-sbt-rpm.repo && \\
+                      |  yum install -y bc gcc gcc-c++ git java-1.8.0-openjdk-headless libcurl-devel libunwind-devel make openssl-devel rpm-build sbt which && \\
+                      |  git clone https://code.googlesource.com/re2 /opt/re2 && \\
+                      |  pushd /opt/re2 && \\
+                      |  git checkout 2017-11-01 && \\
+                      |  make && \\
+                      |  make install && \\
+                      |  popd
+                      |RUN yum install -y libstdc++-devel libstdc++-static
+                      |""".stripMargin,
+        target = new RpmBuildTarget("el7", "bash,libunwind,libcurl", Seq("/opt/re2/obj/so/libre2.so.0"))),
+
+      BuildInfo(
+        name = "debian-8",
+        baseImage = "debian:8",
+        install = s"""|RUN \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install apt-transport-https && \\
+                      |  echo "deb http://ftp.de.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list && \\
+                      |  echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list && \\
+                      |  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install -t jessie-backports openjdk-8-jre-headless ca-certificates-java && \\
+                      |  apt-get -y install bc build-essential clang++-3.8 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
+                      |""".stripMargin,
+        target = DebBuildTarget(Seq("jessie"), "main", "bash,libcurl3,libre2-1,libunwind8", Seq.empty)),
+
+      BuildInfo(
+        name = "debian-9",
+        baseImage = "debian:9",
+        install = s"""|RUN \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install apt-transport-https gnupg && \\
+                      |  echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list && \\
+                      |  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install bc build-essential clang++-3.9 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev openjdk-8-jdk-headless sbt
+                      |""".stripMargin,
+        target = DebBuildTarget(Seq("stretch"), "main", "bash,libcurl3,libre2-3,libunwind8", Seq.empty)),
+
+      MuslBuild.deb("ubuntu-older", Seq("trusty", "utopic", "vivid", "wily"), "main", "bash"),
+
+      BuildInfo(
+        name = "ubuntu-16-04",
+        baseImage = "ubuntu:16.04",
+        install = s"""|RUN \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install apt-transport-https && \\
+                      |  echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list && \\
+                      |  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install bc build-essential openjdk-8-jre-headless ca-certificates-java clang++-3.8 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
+                      |""".stripMargin,
+        target = DebBuildTarget(Seq("xenial"), "main", "bash,libre2-1v5,libunwind8,libcurl3", Seq.empty)),
+
+      BuildInfo(
+        name = "ubuntu-16-10",
+        baseImage = "ubuntu:16.10",
+        install = s"""|RUN \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install apt-transport-https dirmngr && \\
+                      |  echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list && \\
+                      |  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install bc build-essential openjdk-8-jre-headless ca-certificates-java clang-3.8 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
+                      |""".stripMargin,
+        target = DebBuildTarget(Seq("yakkety"), "main", "bash,libre2-2,libunwind8,libcurl3", Seq.empty)),
+
+      BuildInfo(
+        name = "ubuntu-17-04_17-10",
+        baseImage = "ubuntu:17.04",
+        install = s"""|RUN \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install apt-transport-https dirmngr && \\
+                      |  echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list && \\
+                      |  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install bc build-essential openjdk-8-jre-headless ca-certificates-java clang-3.8 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
+                      |""".stripMargin,
+        target = DebBuildTarget(Seq("zesty", "artful"), "main", "bash,libre2-3,libunwind8,libcurl3", Seq.empty)))
+}
+
+object MuslBuild {
+  private val image = "openjdk:8u121-jre-alpine"
+
+  private val install =
+    s"""|RUN \\
+        |  apk --update add bash build-base clang curl-dev dpkg gc-dev git libc-dev musl-dev rpm tar wget && \\
+        |  apk add libunwind-dev --update-cache --repository http://nl.alpinelinux.org/alpine/edge/main && \\
+        |  git clone https://code.googlesource.com/re2 /opt/re2 && \\
+        |  cd /opt/re2 && \\
+        |  git checkout 2017-11-01 && \\
+        |  CXX=clang++ make && \\
+        |  make install && \\
+        |  cd - && \\
+        |  mkdir /opt/sbt && \\
+        |  wget -qO - --no-check-certificate "https://dl.bintray.com/sbt/native-packages/sbt/0.13.15/sbt-0.13.15.tgz" | tar xz -C /opt/sbt --strip-components=1
+        |
+        |ENV PATH /opt/sbt/bin:$${PATH}
+        |
+        |# Have to hack around a few things -- make sure our dynamic linker is in place,
+        |# initialize the RPM database, and make /var/tmp writable for reactive-cli user to use
+        |
+        |RUN \\
+        |  mkdir -p /usr/share/reactive-cli/lib/ && chmod 777 /usr/share/reactive-cli/lib/ && \\
+        |  rpm --quiet -qa && \\
+        |  chmod -R 777 /var/tmp
+        |""".stripMargin
+
+  private val libs =
+    Seq(
+      "/opt/re2/obj/so/libre2.so.0",
+      "/usr/lib/libunwind.so.8",
+      "/usr/lib/libunwind-x86_64.so.8",
+      "/usr/lib/libgc.so.1",
+      "/usr/lib/libstdc++.so.6",
+      "/usr/lib/libgcc_s.so.1",
+      "/lib/ld-musl-x86_64.so.1",
+      "/lib/libc.musl-x86_64.so.1",
+      "/usr/lib/libcrypto.so.38",
+      "/usr/lib/libcurl.so.4",
+      "/usr/lib/libssh2.so.1",
+      "/usr/lib/libssl.so.39",
+      "/lib/libz.so.1")
+
+  private val preBuild =
+    """|cp -p /lib/ld-musl-x86_64.so.1 /usr/share/reactive-cli/lib/
+       |""".stripMargin
+
+  private val sbtBuildArguments =
+    """-Dbuild.dynamicLinker=/usr/share/reactive-cli/lib/ld-musl-x86_64.so.1"""
+
+  def deb(name: String, distributions: Seq[String], components: String, dependencies: String): BuildInfo = new BuildInfo(
+    name = name,
+    baseImage = image,
+    install = install,
+    target = new DebBuildTarget(distributions, components, dependencies, libs) {
+      override protected def preBuildHook: String = preBuild
+
+      override protected def sbtBuildArgumentsHook: String = sbtBuildArguments
+    })
+
+  def rpm(name: String, release: String, requires: String): BuildInfo = new BuildInfo(
+    name = name,
+    baseImage = image,
+    install = install,
+    target = new RpmBuildTarget(release, requires, libs) {
+      override protected def preBuildHook: String = preBuild
+
+      override protected def sbtBuildArgumentsHook: String = sbtBuildArguments
+    })
+}
+
+case class BuildInfo(name: String, baseImage: String, install: String, target: BuildTarget) {
+  val argonautCommit = "2c719f155744881d30fc932dcbbf597a9ce8084c"
+  val dockerBuildImage = s"reactive-cli-build-$name"
+
+  def run(root: File, stage: File, version: String, log: Logger): Seq[File] = {
+    def clearStage(): Unit = {
+      IO.delete(stage)
+      IO.createDirectory(stage)
+    }
+
+    def copyArgonaut(): Unit = {
+      val argonautDir = root / "target" / "argonaut" / argonautCommit
+
+      if (!argonautDir.isDirectory) {
+        BuildInfo.synchronized {
+          // builds are done in parallel but we ensure that only one of them does the git clone on argonaut
+
+          if (!argonautDir.isDirectory) {
+            log.info(s"[$name] cloning argonaut")
+
+            val argonautTempDir = root / "target" / "argonaut" / "temporary" / argonautCommit
+
+            IO.createDirectory(argonautTempDir)
+
+            AdditionalIO.runProcess("git", "clone", "https://github.com/argonaut-io/argonaut.git", argonautTempDir.getAbsolutePath)
+
+            AdditionalIO.runProcessCwd(argonautTempDir, "git", "checkout", argonautCommit)
+
+            // Remove coursier so we use the ivy cache
+
+            IO.writeLines(
+              argonautTempDir / "project" / "plugins.sbt",
+              IO.readLines(argonautTempDir / "project" / "plugins.sbt").filterNot(_.contains("sbt-coursier")))
+
+            IO.move(argonautTempDir, argonautDir)
+          }
+        }
+      }
+
+      log.info(s"[$name] copying argonaut")
+
+      IO.copyDirectory(argonautDir, stage / "argonaut")
+    }
+
+    def copyIvyCache(): Unit = {
+      if ((Path.userHome / ".ivy2" / "cache").isDirectory) {
+        log.info(s"[$name] copying ivy cache")
+        IO.copyDirectory(Path.userHome / ".ivy2" / "cache", stage / ".ivy2" / "cache")
+      }
+    }
+
+    def copyProject(): Unit = {
+      log.info(s"[$name] copying project")
+
+      val filter =
+        new SimpleFileFilter(f => f.getPath.contains(s"${Path.sep}target") || f.getPath.contains(s"${Path.sep}.git"))
+
+      for {
+        source <- (root ** -(DirectoryFilter || filter)).get
+        destination <- Path.rebase(root, stage / "reactive-cli")(source)
+      } IO.copyFile(source, destination)
+    }
+
+    def build(): Vector[File] = {
+      val userId = Seq("id", "-u").!!.trim.toInt
+
+      val dockerFile =
+        s"""|FROM $baseImage
+            |LABEL REBUILD=20171108-01
+            |MAINTAINER info@lightbend.com
+            |
+            |$install
+            |
+            |RUN \\
+            |  (which useradd && useradd -m reactive-cli -d /home/reactive-cli -u $userId) || (which adduser && adduser -D -u $userId -h /home/reactive-cli reactive-cli) && \\
+            |  mkdir -p /home/reactive-cli/stage && \\
+            |  chown -R reactive-cli:reactive-cli /home/reactive-cli
+            |
+            |WORKDIR /home/reactive-cli/stage
+            |USER reactive-cli
+            |CMD ["./command"]
+            |""".stripMargin
+
+      IO.createDirectory(stage / ".context")
+      IO.createDirectory(stage / "output")
+
+      IO.write(stage / ".context" / "Dockerfile", dockerFile)
+
+      runProcessCwd(stage / ".context", "docker", "build", "-t", dockerBuildImage, (stage / ".context").getPath)
+
+      target.prepare(stage, this, version)
+
+      runProcess(
+        "docker",
+        "run",
+        "--rm=true",
+
+        "--env", "BINTRAY_USER=none", // Quiet the Bintray warnings from sbt-bintray
+        "--env", "BINTRAY_PASS=none",
+
+        "-v", s"$stage:/home/reactive-cli/stage",
+        "-v", s"${stage / ".ivy2"}:/home/reactive-cli/.ivy2",
+        s"$dockerBuildImage:latest")
+
+      IO.listFiles(stage / "output").toVector
+    }
+
+    log.info(s"[$name] building")
+
+    clearStage()
+
+    copyProject()
+
+    copyIvyCache()
+
+    copyArgonaut()
+
+    build()
+  }
+}

--- a/project/BuildTarget.scala
+++ b/project/BuildTarget.scala
@@ -1,0 +1,212 @@
+import sbt._
+import scala.collection.immutable.Seq
+
+trait BuildTarget {
+  // These fields are hard-coded for now but could become arguments if we generalize this build setup
+
+  protected val buildDescription = "Tools for the Lightbend Reactive Platform"
+  protected val buildLicense = "Apache 2.0"
+  protected val buildPackage = "reactive-cli"
+  protected val buildDebArch = "amd64"
+  protected val buildDebMaintainer = "Lightbend, Inc"
+  protected val buildRpmArch = "x86_64"
+  protected val buildRpmSummary = "Reactive CLI"
+  protected val buildRpmVendor = "Lightbend, Inc <info@lightbend.com>"
+
+  /**
+   * Should create a script at stage/command that will build the project
+   * and create any appropriate packages in stage/output
+   */
+  def prepare(stage: File, info: BuildInfo, version: String): Unit
+
+  protected def postBuildHook: String = ""
+
+  protected def preBuildHook: String = ""
+
+  protected def sbtBuildArgumentsHook: String = ""
+
+  protected def launcherHook: String = ""
+
+  /**
+   * Creates a file at stage/build that will build the project but not package it
+   */
+  protected def prepareBuild(stage: File, version: String, libs: Seq[(String, String)]): Unit = {
+    val launcher =
+      s"""|#!/usr/bin/env bash
+         |
+         |if [ -d "/usr/share/reactive-cli/lib" ]; then
+         |  if [ "$$LD_LIBRARY_PATH" = "" ]; then
+         |    export LD_LIBRARY_PATH="/usr/share/reactive-cli/lib"
+         |  else
+         |    export LD_LIBRARY_PATH="/usr/share/reactive-cli/lib:$$LD_LIBRARY_PATH"
+         |  fi
+         |fi
+         |
+         |$launcherHook
+         |
+         |exec /usr/share/reactive-cli/bin/rp "$$@"
+         |""".stripMargin
+
+    IO.createDirectory(stage / "package" / "usr" / "bin")
+    IO.createDirectory(stage / "package" / "usr" / "share" / "reactive-cli" / "bin")
+    IO.createDirectory(stage / "package" / "usr" / "share" / "reactive-cli" / "lib")
+    IO.write(stage / "package" / "usr" / "share" / "reactive-cli" / "bin" / "rp-launcher", launcher)
+    AdditionalIO.setExecutable(stage / "package" / "usr" / "share" / "reactive-cli" / "bin" / "rp-launcher")
+
+    IO.write(
+      stage / "build",
+      s"""|#!/usr/bin/env bash
+          |
+          |# This is executed within the container. It runs the SBT build and creates a local package directory.
+          |
+          |set -e
+          |
+          |export STAGE="$$(pwd)"
+          |
+          |pushd argonaut
+          |sbt argonautNative/publishLocal
+          |popd
+          |
+          |pushd reactive-cli
+          |
+          |${libs.map { case (p, n) => s"cp -p '$p' '../package/usr/share/reactive-cli/lib/$n'" }.mkString("\n")}
+          |
+          |if [ "$$LD_LIBRARY_PATH" = "" ]; then
+          |  export LD_LIBRARY_PATH="$$STAGE/package/usr/share/reactive-cli/lib"
+          |else
+          |  export LD_LIBRARY_PATH="$$STAGE/package/usr/share/reactive-cli/lib:$$LD_LIBRARY_PATH"
+          |fi
+          |
+          |$preBuildHook
+          |
+          |sbt -Dbuild.nativeMode=debug $sbtBuildArgumentsHook clean test package
+          |
+          |$postBuildHook
+          |
+          |mv target/output/bin/* ../package/usr/share/reactive-cli/bin/
+          |mv target/output/lib/* ../package/usr/share/reactive-cli/lib/
+          |ln -s /usr/share/reactive-cli/bin/rp-launcher ../package/usr/bin/rp
+          |popd
+          |""".stripMargin)
+
+    AdditionalIO.setExecutable(stage / "build")
+  }
+
+  protected def parseLibs(libs: Seq[String]): Seq[(String, String)] =
+    libs.map(l => l -> l.reverse.takeWhile(_ != '/').reverse)
+}
+
+object RpmBuildTarget {
+  def normalizeVersion(version: String): String =
+    version.replaceAll("-", ".")
+}
+
+case class RpmBuildTarget(release: String, requires: String, libs: Seq[String]) extends BuildTarget {
+  def prepare(stage: File, info: BuildInfo, version: String): Unit = {
+    val libPathToName = parseLibs(libs)
+
+    prepareBuild(stage, version, libPathToName)
+
+    IO.createDirectory(stage / "package" / "BUILD")
+
+    IO.createDirectory(stage / "package" / "RPMS")
+
+    val spec =
+      s"""|Summary:        $buildRpmSummary
+          |Name:           $buildPackage
+          |Version:        ${RpmBuildTarget.normalizeVersion(version)}
+          |Release:        $release
+          |License:        $buildLicense
+          |Source:         %{expand:%%(pwd)}
+          |BuildArch:      $buildRpmArch
+          |BuildRoot:      %{_tmppath}/%{name}-build
+          |Group:          System/Base
+          |Vendor:         $buildRpmVendor
+          |AutoReqProv:    no
+          |Requires:       $requires
+          |
+          |%define _rpmdir package/RPMS/
+          |
+          |%description
+          |$buildDescription
+          |
+          |%prep
+          |rm -rf "$$RPM_BUILD_ROOT"
+          |mkdir -p "$$RPM_BUILD_ROOT"
+          |cp -rp "$$STAGE/package/usr" "$$RPM_BUILD_ROOT/usr"
+          |
+          |%clean
+          |rm -rf "$$RPM_BUILD_ROOT"
+          |
+          |%files
+          |%defattr(-,root,root)
+          |/usr/bin/rp
+          |/usr/share/reactive-cli/bin/rp
+          |/usr/share/reactive-cli/bin/rp-launcher
+          |/usr/share/reactive-cli/lib/libhttpsimple.so
+          |${libPathToName.map(e => s"/usr/share/reactive-cli/lib/${e._2}").mkString("\n")}
+          |""".stripMargin
+
+    IO.write(stage / "package" / "reactive-cli.spec", spec)
+
+    IO.write(
+      stage / "command",
+      s"""|#!/usr/bin/env bash
+          |
+          |# This is executed within the container. It runs the SBT build (via ./build) and creates the .rpm package
+          |
+          |set -e
+          |
+          |bash ./build
+          |
+          |export STAGE="$$(pwd)"
+          |
+          |rpmbuild -bb package/reactive-cli.spec
+          |
+          |mv package/RPMS/*/* output/
+          |""".stripMargin)
+
+    AdditionalIO.setExecutable(stage / "command")
+  }
+}
+
+case class DebBuildTarget(distributions: Seq[String], components: String, dependencies: String, libs: Seq[String]) extends BuildTarget {
+  val architecture = "amd64"
+
+  def prepare(stage: File, info: BuildInfo, version: String): Unit = {
+    val libPathToName = parseLibs(libs)
+
+    prepareBuild(stage, version, libPathToName)
+
+    val control =
+      s"""|Package: $buildPackage
+          |Version: $version
+          |Maintainer: $buildDebMaintainer
+          |License: $buildLicense
+          |Architecture: $architecture
+          |Description: $buildDescription
+          |Depends: $dependencies
+          |""".stripMargin
+
+    IO.createDirectory(stage / "package" / "DEBIAN")
+
+    IO.write(stage / "package" / "DEBIAN" / "control", control)
+
+    IO.write(
+      stage / "command",
+      s"""|#!/usr/bin/env bash
+          |
+          |# This is executed within the container. It runs the SBT build (via .build) and creates the .deb package
+          |
+          |set -e
+          |
+          |bash ./build
+          |
+          |dpkg --build package
+          |
+          |mv package.deb output/reactive-cli_$version-${distributions.mkString("-")}_$architecture.deb
+          |""".stripMargin)
+
+    AdditionalIO.setExecutable(stage / "command")
+  }
+}

--- a/project/Properties.scala
+++ b/project/Properties.scala
@@ -1,0 +1,5 @@
+object Properties {
+  val concurrentBuilds = Option(System.getProperty("build.concurrentBuilds")).map(_.toInt).getOrElse(2)
+  val dynamicLinker = Option(System.getProperty("build.dynamicLinker"))
+  val nativeMode = System.getProperty("build.nativeMode", "debug")
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,14 @@
 val Versions = new {
-  val sbtHeader         = "3.0.1"
-  val sbtNativePackager = "1.2.0"
+  val sbtBintray         = "0.5.1"
+  val sbtHeader          = "3.0.1"
+  val sbtNativePackager  = "1.2.0"
+  val sbtRelease         = "1.0.6"
   val sbtScalaNative     = "0.3.3"
   val sbtScalariform     = "1.8.0"
 }
 
-addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager" % Versions.sbtNativePackager)
+addSbtPlugin("com.github.gseitz"  % "sbt-release"         % Versions.sbtRelease)
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"          % Versions.sbtHeader)
+addSbtPlugin("org.foundweekends"  % "sbt-bintray"         % Versions.sbtBintray)
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"    % Versions.sbtScalaNative)
 addSbtPlugin("org.scalariform"    % "sbt-scalariform"     % Versions.sbtScalariform)

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.0.1-SNAPSHOT"


### PR DESCRIPTION
This PR implements a build pipeline that uses Docker to build `.rpm` and `.deb` for various Linux distributions, and configures `sbt-release` to push these to Bintray so that they can be resolved using standard package manager tools.

When possible, the distribution's regular packages are used for building and dependency declaration. When not possible (Older Ubuntu, CentOS6), a build is done in Alpine against musl for libc and everything is packaged with the application.

In a follow-up PR, sometime in the future, I'd like to add support for creating `.tar.gz` files, as well as exploring Fedora and possibly Arch via AUR.