### PR TITLE
Support connection to Docker private registry

### DIFF
--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -16,6 +16,8 @@
 
 package com.lightbend.rp.reactivecli.argparse
 
+import GenerateDeploymentArgs.{ DockerRegistryUseHttpsDefault, DockerRegistryValidateTlsDefault }
+
 /**
  * Base type which represents input argument for a specific command invoked by the user.
  */
@@ -24,6 +26,9 @@ sealed trait CommandArgs
 object VersionArgs extends CommandArgs
 
 object GenerateDeploymentArgs {
+  val DockerRegistryUseHttpsDefault = true
+  val DockerRegistryValidateTlsDefault = true
+
   /**
    * Convenience method to set the [[GenerateDeploymentArgs]] values when parsing the complete user input.
    * Refer to [[InputArgs.parser()]] for more details.
@@ -49,4 +54,8 @@ case class GenerateDeploymentArgs(
   nrOfCpus: Option[Double] = None,
   memory: Option[Long] = None,
   diskSpace: Option[Long] = None,
-  targetRuntimeArgs: Option[TargetRuntimeArgs] = None) extends CommandArgs
+  targetRuntimeArgs: Option[TargetRuntimeArgs] = None,
+  registryUsername: Option[String] = None,
+  registryPassword: Option[String] = None,
+  registryUseHttps: Boolean = DockerRegistryUseHttpsDefault,
+  registryValidateTls: Boolean = DockerRegistryValidateTlsDefault) extends CommandArgs

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -66,7 +66,6 @@ object InputArgs {
         .text("Sets the log level. Available: error, warn, info, debug, trace")
         .action((v, c) => c.copy(logLevel = v))
 
-
       cmd("version")
         .text("Outputs the program's version")
         .action((_, inputArgs) => inputArgs.copy(commandArgs = Some(VersionArgs)))

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -17,6 +17,7 @@
 package com.lightbend.rp.reactivecli.argparse
 
 import java.io.File
+import java.nio.file.{ Path, Paths }
 
 import com.lightbend.rp.reactivecli.argparse.kubernetes.{ DeploymentArgs, IngressArgs, KubernetesArgs, ServiceArgs }
 import com.lightbend.rp.reactivecli.runtime.kubernetes.Deployment
@@ -65,9 +66,15 @@ object InputArgs {
         .text("Sets the log level. Available: error, warn, info, debug, trace")
         .action((v, c) => c.copy(logLevel = v))
 
+
       cmd("version")
         .text("Outputs the program's version")
         .action((_, inputArgs) => inputArgs.copy(commandArgs = Some(VersionArgs)))
+
+      opt[File]("cainfo")
+        .text("Path to the CA certs for TLS validation purposes")
+        .validate(f => if (f.exists()) success else failure(s"CA certs file ${f.getAbsolutePath} doesn't exist."))
+        .action((f, c) => c.copy(tlsCacertsPath = Some(f.toPath.toAbsolutePath)))
 
       cmd("generate-deployment")
         .text("Generate deployment resources")
@@ -156,8 +163,52 @@ object InputArgs {
           opt[Long]("disk-space")
             .text("Specify the disk space limit")
             .optional()
-            .action(GenerateDeploymentArgs.set((v, c) => c.copy(diskSpace = Some(v)))))
+            .action(GenerateDeploymentArgs.set((v, c) => c.copy(diskSpace = Some(v)))),
+
+          opt[String]("registry-username")
+            .text("Specify username to access docker registry. Password must be specified also.")
+            .optional()
+            .action(GenerateDeploymentArgs.set((v, c) => c.copy(registryUsername = Some(v)))),
+
+          opt[String]("registry-password")
+            .text("Specify password to access docker registry. Username must be specified also.")
+            .optional()
+            .action(GenerateDeploymentArgs.set((v, c) => c.copy(registryPassword = Some(v)))),
+
+          opt[Unit]("registry-https-disable")
+            .text("Disables HTTPS when accessing docker registry")
+            .optional()
+            .action(GenerateDeploymentArgs.set((_, c) => c.copy(registryUseHttps = false))),
+
+          opt[Unit]("registry-tls-validation-disable")
+            .text("Disables TLS cert validation when accessing docker registry through HTTPS")
+            .optional()
+            .action(GenerateDeploymentArgs.set((_, c) => c.copy(registryValidateTls = false))))
+
+      checkConfig { inputArgs =>
+        inputArgs.commandArgs match {
+          case Some(v: GenerateDeploymentArgs) =>
+            if (v.registryUsername.isDefined && v.registryPassword.isEmpty)
+              failure("Registry password can't be empty if registry username is specified")
+            else if (v.registryUsername.isEmpty && v.registryPassword.isDefined)
+              failure("Registry username can't be empty if registry password is specified")
+            else
+              success
+          case _ =>
+            success
+        }
+      }
     }
+
+  object Envs {
+    val RP_CAINFO = "RP_CAINFO"
+
+    def mergeWithEnvs(inputArgs: InputArgs, envs: Map[String, String]): InputArgs = {
+      val tlsCacertsPathEnv = envs.get(RP_CAINFO).map(Paths.get(_))
+      inputArgs.tlsCacertsPath.orElse(tlsCacertsPathEnv)
+        .fold(inputArgs)(v => inputArgs.copy(tlsCacertsPath = Some(v)))
+    }
+  }
 
 }
 
@@ -166,4 +217,5 @@ object InputArgs {
  */
 case class InputArgs(
   logLevel: LogLevel = LogLevel.INFO,
+  tlsCacertsPath: Option[Path] = None,
   commandArgs: Option[CommandArgs] = None)

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -16,7 +16,7 @@
 
 package com.lightbend.rp.reactivecli.argparse
 
-import java.nio.file.Paths
+import java.nio.file.{ Files, Paths }
 
 import com.lightbend.rp.reactivecli.argparse.kubernetes.{ DeploymentArgs, IngressArgs, KubernetesArgs, ServiceArgs }
 import com.lightbend.rp.reactivecli.runtime.kubernetes.Deployment
@@ -52,44 +52,86 @@ object InputArgsTest extends TestSuite {
           }
 
           "all arguments" - {
-            val result = parser.parse(
-              Seq(
+            val mockCacerts = Files.createTempFile("cacerts", "test")
+
+            try {
+              val result = parser.parse(
+                Seq(
+                  "generate-deployment",
+                  "--loglevel", "debug",
+                  "--cainfo", mockCacerts.toAbsolutePath.toString,
+                  "dockercloud/hello-world:1.0.0-SNAPSHOT",
+                  "--target", "kubernetes",
+                  "--kubernetes-version", "1.7",
+                  "--kubernetes-deployment-nr-of-replicas", "10",
+                  "--kubernetes-deployment-image-pull-policy", "Always",
+                  "--kubernetes-service-cluster-ip", "10.0.0.1",
+                  "--kubernetes-ingress-annotation", "ing=123",
+                  "--kubernetes-ingress-path-append", ".*",
+                  "--env", "test1=test2",
+                  "--nr-of-cpus", "0.5",
+                  "--memory", "1024",
+                  "--disk-space", "2048",
+                  "--output", "/tmp/foo",
+                  "--registry-username", "john",
+                  "--registry-password", "wick",
+                  "--registry-https-disable",
+                  "--registry-tls-validation-disable"),
+                InputArgs.default)
+              assert(
+                result.contains(
+                  InputArgs(
+                    logLevel = LogLevel.DEBUG,
+                    tlsCacertsPath = Some(mockCacerts),
+                    commandArgs = Some(GenerateDeploymentArgs(
+                      dockerImage = Some("dockercloud/hello-world:1.0.0-SNAPSHOT"),
+                      targetRuntimeArgs = Some(KubernetesArgs(
+                        kubernetesVersion = Some(KubernetesVersion(1, 7)),
+                        output = KubernetesArgs.Output.SaveToFile(Paths.get("/tmp/foo")),
+                        deploymentArgs = DeploymentArgs(
+                          numberOfReplicas = 10,
+                          imagePullPolicy = Deployment.ImagePullPolicy.Always),
+                        serviceArgs = ServiceArgs(clusterIp = Some("10.0.0.1")),
+                        ingressArgs = IngressArgs(
+                          ingressAnnotations = Map("ing" -> "123"),
+                          pathAppend = Some(".*")))),
+                      environmentVariables = Map("test1" -> "test2"),
+                      nrOfCpus = Some(0.5),
+                      memory = Some(1024),
+                      diskSpace = Some(2048),
+                      registryUsername = Some("john"),
+                      registryPassword = Some("wick"),
+                      registryUseHttps = false,
+                      registryValidateTls = false)))))
+            } finally {
+              Files.deleteIfExists(mockCacerts)
+            }
+
+            "registry credentials" - {
+              val baseArgs = Seq(
                 "generate-deployment",
                 "dockercloud/hello-world:1.0.0-SNAPSHOT",
                 "--target", "kubernetes",
-                "--kubernetes-version", "1.7",
-                "--kubernetes-deployment-nr-of-replicas", "10",
-                "--kubernetes-deployment-image-pull-policy", "Always",
-                "--kubernetes-service-cluster-ip", "10.0.0.1",
-                "--kubernetes-ingress-annotation", "ing=123",
-                "--kubernetes-ingress-path-append", ".*",
-                "--env", "test1=test2",
-                "--nr-of-cpus", "0.5",
-                "--memory", "1024",
-                "--disk-space", "2048",
-                "--output", "/tmp/foo",
-                "--loglevel", "debug"),
-              InputArgs.default)
-            assert(
-              result.contains(
-                InputArgs(
-                  logLevel = LogLevel.DEBUG,
-                  commandArgs = Some(GenerateDeploymentArgs(
-                    dockerImage = Some("dockercloud/hello-world:1.0.0-SNAPSHOT"),
-                    targetRuntimeArgs = Some(KubernetesArgs(
-                      kubernetesVersion = Some(KubernetesVersion(1, 7)),
-                      output = KubernetesArgs.Output.SaveToFile(Paths.get("/tmp/foo")),
-                      deploymentArgs = DeploymentArgs(
-                        numberOfReplicas = 10,
-                        imagePullPolicy = Deployment.ImagePullPolicy.Always),
-                      serviceArgs = ServiceArgs(clusterIp = Some("10.0.0.1")),
-                      ingressArgs = IngressArgs(
-                        ingressAnnotations = Map("ing" -> "123"),
-                        pathAppend = Some(".*")))),
-                    environmentVariables = Map("test1" -> "test2"),
-                    nrOfCpus = Some(0.5),
-                    memory = Some(1024),
-                    diskSpace = Some(2048))))))
+                "--kubernetes-version", "1.7")
+
+              "should fail if username is defined but password is empty" - {
+                val result = parser.parse(
+                  baseArgs ++ Seq(
+                    "--registry-username", "john"),
+                  InputArgs.default)
+
+                assert(result.isEmpty)
+              }
+
+              "should fail if username is empty but password is defined" - {
+                val result = parser.parse(
+                  baseArgs ++ Seq(
+                    "--registry-password", "wick"),
+                  InputArgs.default)
+
+                assert(result.isEmpty)
+              }
+            }
           }
         }
       }
@@ -97,6 +139,27 @@ object InputArgsTest extends TestSuite {
       "with default arguments" - {
         val result = parser.parse(Seq.empty, InputArgs.default)
         assert(result.contains(InputArgs.default))
+      }
+    }
+
+    "merge with envs" - {
+      "RP_CAINFO" - {
+        "should use the value from environment" - {
+          val inputArgs = InputArgs()
+          val result = InputArgs.Envs.mergeWithEnvs(inputArgs, Map(InputArgs.Envs.RP_CAINFO -> "/path/cacerts"))
+          val expectedResult = InputArgs(
+            tlsCacertsPath = Some(Paths.get("/path/cacerts")))
+          assert(result == expectedResult)
+        }
+
+        "should prefer value from the input args" - {
+          val inputArgs = InputArgs(
+            tlsCacertsPath = Some(Paths.get("/my/cacerts")))
+          val result = InputArgs.Envs.mergeWithEnvs(inputArgs, Map(InputArgs.Envs.RP_CAINFO -> "/path/cacerts"))
+          val expectedResult = InputArgs(
+            tlsCacertsPath = Some(Paths.get("/my/cacerts")))
+          assert(result == expectedResult)
+        }
       }
     }
   }

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
@@ -22,31 +22,63 @@ import utest._
 object DockerRegistryTest extends TestSuite {
   val tests = this{
     "blobUrl" - {
-      assert(
-        DockerRegistry.blobUrl(
-          Image(
-            DockerDefaultRegistry,
-            DockerDefaultLibrary,
-            "alpine",
-            "3.5",
-            None,
-            None,
-            "alpine",
-            Some("3.5")), "abc123") == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/blobs/abc123")
+      "with https" - {
+        assert(
+          DockerRegistry.blobUrl(
+            Image(
+              DockerDefaultRegistry,
+              DockerDefaultLibrary,
+              "alpine",
+              "3.5",
+              None,
+              None,
+              "alpine",
+              Some("3.5")), "abc123", useHttps = true) == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/blobs/abc123")
+      }
+
+      "with http" - {
+        assert(
+          DockerRegistry.blobUrl(
+            Image(
+              DockerDefaultRegistry,
+              DockerDefaultLibrary,
+              "alpine",
+              "3.5",
+              None,
+              None,
+              "alpine",
+              Some("3.5")), "abc123", useHttps = false) == s"http://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/blobs/abc123")
+      }
     }
 
     "manifestUrl" - {
-      assert(
-        DockerRegistry.manifestUrl(
-          Image(
-            DockerDefaultRegistry,
-            DockerDefaultLibrary,
-            "alpine",
-            "3.5",
-            None,
-            None,
-            "alpine",
-            Some("3.5"))) == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/manifests/3.5")
+      "with https" - {
+        assert(
+          DockerRegistry.manifestUrl(
+            Image(
+              DockerDefaultRegistry,
+              DockerDefaultLibrary,
+              "alpine",
+              "3.5",
+              None,
+              None,
+              "alpine",
+              Some("3.5")), useHttps = true) == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/manifests/3.5")
+      }
+
+      "with http" - {
+        assert(
+          DockerRegistry.manifestUrl(
+            Image(
+              DockerDefaultRegistry,
+              DockerDefaultLibrary,
+              "alpine",
+              "3.5",
+              None,
+              None,
+              "alpine",
+              Some("3.5")), useHttps = false) == s"http://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/manifests/3.5")
+      }
     }
 
     "parseImageUri" - {

--- a/cli/src/test/scala/libhttpsimple/Base64Test.scala
+++ b/cli/src/test/scala/libhttpsimple/Base64Test.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libhttpsimple
+
+import utest._
+
+// FIXME scala native doesn't seem to like tests in two different projects in the
+// FIXME same build so it throws a [error] (cli/nativetest:nativeLinkNIR) java.nio.file.FileSystemAlreadyExistsException
+
+object Base64Test extends TestSuite {
+  val tests = this{
+    "Encode Strings to base64" - {
+      val tests = Map(
+        "abc" -> "YWJj",
+        "test" -> "dGVzdA==",
+        "a" -> "YQ==",
+        "ab" -> "YWI=",
+        "abc" -> "YWJj",
+        "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjAxMjM0" -> "WVdKalpHVm1aMmhwYW10c2JXNXZjSEZ5YzNSMWRuZDRlWHBCUWtORVJVWkhTRWxLUzB4TlRrOVFVVkpUVkZWV1YxaFpXakF4TWpNMA==")
+
+      tests.foreach {
+        case (in, out) =>
+          val encoded = Base64Encoder(in)
+
+          assert(encoded == out)
+      }
+    }
+  }
+}

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/Base64Encoder.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/Base64Encoder.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libhttpsimple
+
+object Base64Encoder {
+  private val charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+  /**
+   * Inspired by https://en.wikibooks.org/wiki/Algorithm_Implementation/Miscellaneous/Base64#Java
+   */
+  def apply(in: String): String = {
+    val charsToPad =
+      if (in.length % 3 == 0)
+        0
+      else
+        3 - (in.length % 3)
+
+    val data = in + ("\u0000" * charsToPad)
+    val rightPad = "=" * charsToPad
+    val builder = new StringBuilder
+
+    var i = 0
+
+    while (i < data.length) {
+      val n = (data.charAt(i) << 16) + (data.charAt(i + 1) << 8) + data.charAt(i + 2)
+
+      builder.append(charSet.charAt((n >> 18) & 63))
+      builder.append(charSet.charAt((n >> 12) & 63))
+      builder.append(charSet.charAt((n >> 6) & 63))
+      builder.append(charSet.charAt(n & 63))
+
+      i += 3
+    }
+
+    builder.substring(0, builder.length - rightPad.length) + rightPad
+  }
+}

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/HttpRequest.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/HttpRequest.scala
@@ -16,16 +16,28 @@
 
 package libhttpsimple
 
+object HttpRequest {
+  sealed trait Auth
+  case class BasicAuth(username: String, password: String) extends Auth
+  case class BearerToken(value: String) extends Auth
+}
+
 case class HttpRequest(
   requestUrl: String,
   requestMethod: String = "GET",
   requestHeaders: HttpHeaders = HttpHeaders(Map.empty),
   requestBody: Option[String] = None,
-  requestFollowRedirects: Boolean = false) {
+  auth: Option[HttpRequest.Auth] = None,
+  requestFollowRedirects: Option[Boolean] = None,
+  tlsValidationEnabled: Option[Boolean] = None) {
 
-  def disableFollowRedirects: HttpRequest = copy(requestFollowRedirects = false)
+  def disableFollowRedirects: HttpRequest = copy(requestFollowRedirects = Some(false))
 
-  def enableFollowRedirects: HttpRequest = copy(requestFollowRedirects = true)
+  def enableFollowRedirects: HttpRequest = copy(requestFollowRedirects = Some(true))
+
+  def disableTlsValidation: HttpRequest = copy(tlsValidationEnabled = Some(false))
+
+  def enableTlsValidation: HttpRequest = copy(tlsValidationEnabled = Some(true))
 
   def get: HttpRequest = copy(requestMethod = "GET")
 
@@ -42,4 +54,8 @@ case class HttpRequest(
   def withHeader(name: String, value: String): HttpRequest = copy(requestHeaders = requestHeaders.updated(name, value))
 
   def withoutHeader(name: String): HttpRequest = copy(requestHeaders = requestHeaders.remove(name))
+
+  def withAuth(auth: HttpRequest.Auth): HttpRequest = copy(auth = Some(auth))
+
+  def withoutAuth: HttpRequest = copy(auth = None)
 }

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/nativebinding/httpsimple.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/nativebinding/httpsimple.scala
@@ -26,7 +26,7 @@ object httpsimple {
 
   def global_init(): CInt = native.extern
   def global_cleanup(): Unit = native.extern
-  def do_http(http_method: CString, url: CString, request_headers_raw: CString, request_body: CString): Ptr[http_response] = native.extern
+  def do_http(validate_tls: CLong, tls_cacerts_path: CString, http_method: CString, url: CString, request_headers_raw: CString, auth_type: CString, auth_value: CString, request_body: CString): Ptr[http_response] = native.extern
   def get_error_code(http_response: Ptr[http_response]): CLong = native.extern
   def get_error_message(http_response: Ptr[http_response]): CString = native.extern
   def get_http_status(http_response: Ptr[http_response]): CLong = native.extern

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/nativebinding/httpsimple.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/nativebinding/httpsimple.scala
@@ -26,7 +26,7 @@ object httpsimple {
 
   def global_init(): CInt = native.extern
   def global_cleanup(): Unit = native.extern
-  def do_http(validate_tls: CLong, tls_cacerts_path: CString, http_method: CString, url: CString, request_headers_raw: CString, auth_type: CString, auth_value: CString, request_body: CString): Ptr[http_response] = native.extern
+  def do_http(validate_tls: CLong, tls_cacerts_path: CString, http_method: CString, url: CString, request_headers_raw: CString, request_body: CString): Ptr[http_response] = native.extern
   def get_error_code(http_response: Ptr[http_response]): CLong = native.extern
   def get_error_message(http_response: Ptr[http_response]): CString = native.extern
   def get_http_status(http_response: Ptr[http_response]): CLong = native.extern

--- a/libhttpsimple/src/main/c/httpsimple.c
+++ b/libhttpsimple/src/main/c/httpsimple.c
@@ -51,7 +51,7 @@ size_t writefunc(void *ptr, size_t size, size_t nmemb, struct http_response *s)
   return size * nmemb;
 }
 
-struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *http_method, char *url, char *request_headers_raw, char *auth_type, char *auth_value, char *request_body) {
+struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *http_method, char *url, char *request_headers_raw, char *request_body) {
   CURL *curl;
   CURLcode res_curl_code;
   struct http_response *s = malloc(sizeof(struct http_response));
@@ -71,15 +71,6 @@ struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *h
 
       if (tls_cacerts_path && strlen(tls_cacerts_path) > 0) {
         curl_easy_setopt(curl, CURLOPT_CAINFO, tls_cacerts_path);
-      }
-
-      if (auth_type && strlen(auth_type) > 0 &&
-            auth_value && strlen(auth_value) > 0) {
-        if (strcmp("basic", auth_type) == 0) {
-            curl_easy_setopt(curl, CURLOPT_USERPWD, auth_value);
-        } else if (strcmp(auth_type, "bearer")) {
-            curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, auth_value);
-        }
       }
 
       // Append request headers if defined

--- a/libhttpsimple/src/main/c/httpsimple.h
+++ b/libhttpsimple/src/main/c/httpsimple.h
@@ -27,7 +27,7 @@ extern int global_init();
 
 extern void global_cleanup();
 
-extern struct http_response *do_http(char *http_method, char *url, char *request_headers_raw, char *request_body);
+extern struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *http_method, char *url, char *request_headers_raw, char *auth_type, char *auth_value, char *request_body);
 
 extern long get_error_code(struct http_response *s);
 

--- a/libhttpsimple/src/main/c/httpsimple.h
+++ b/libhttpsimple/src/main/c/httpsimple.h
@@ -27,7 +27,7 @@ extern int global_init();
 
 extern void global_cleanup();
 
-extern struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *http_method, char *url, char *request_headers_raw, char *auth_type, char *auth_value, char *request_body);
+extern struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *http_method, char *url, char *request_headers_raw, char *request_body);
 
 extern long get_error_code(struct http_response *s);
 


### PR DESCRIPTION
This PR will allow Reactive CLI to connect to Docker private registry.

The following connectivity options are available:
* Allowing for both `http` or `https` connectivity.
* Disabling TLS validation to allow connectivity to private registry with self-signed cert.
* Specifying custom CA information to allow connectivity to private registry with self-signed cert.
* Allowing user to specify username and password which is used to connect to the private registry.

---
* [x] Input args to disable SSL and SSL cert validation.
* [x] Allow disabling SSL when accessing docker registry.
* [x] Allow disabling SSL validation when accessing docker registry.
* [x] Specify location of the `CACERTS` when validating SSL cert: https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html
* [x] Expose environment variable to control CACERT location - environment variable name to match option switch with uppercase & underscore with `RP_` prefix, i.e. `RP_TLS_CACERTS_PATH`
* [x] Support docker registry base64 authentication.
* [ ] Manual test