### PR TITLE
Implement rp version command

### DIFF
--- a/cli/build.sbt
+++ b/cli/build.sbt
@@ -16,3 +16,19 @@ nativeLinkingOptions := {
     "-L", (baseDirectory.value / ".." / "libhttpsimple" / "target").toPath.toAbsolutePath.toString
   ) ++ sys.props.get("nativeLinkingOptions").fold(Seq.empty[String])(_.split(" ").toVector)
 }
+
+sourceGenerators in Compile += Def.task {
+  val versionFile = (sourceManaged in Compile).value / "ProgramVersion.scala"
+
+  val versionSource =
+    """|package com.lightbend.rp.reactivecli
+       |
+       |object ProgramVersion {
+       |  val current = "%s"
+       |}
+    """.stripMargin.format(version.value)
+
+  IO.write(versionFile, versionSource)
+
+  Seq(versionFile)
+}

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -21,6 +21,8 @@ package com.lightbend.rp.reactivecli.argparse
  */
 sealed trait CommandArgs
 
+object VersionArgs extends CommandArgs
+
 object GenerateDeploymentArgs {
   /**
    * Convenience method to set the [[GenerateDeploymentArgs]] values when parsing the complete user input.

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -65,6 +65,10 @@ object InputArgs {
         .text("Sets the log level. Available: error, warn, info, debug, trace")
         .action((v, c) => c.copy(logLevel = v))
 
+      cmd("version")
+        .text("Outputs the program's version")
+        .action((_, inputArgs) => inputArgs.copy(commandArgs = Some(VersionArgs)))
+
       cmd("generate-deployment")
         .text("Generate deployment resources")
         .action((_, inputArgs) => inputArgs.copy(commandArgs = Some(GenerateDeploymentArgs())))


### PR DESCRIPTION
This adds `rp version`:

```
~/work/lightbend/reactive-cli#version $  ./cli/target/scala-2.11/reactive-cli-out version
rp (Reactive CLI) 0.0.1-SNAPSHOT
-> 0
```