### PR TITLE
Implement namespace support

### DIFF
--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -106,6 +106,10 @@ object InputArgs {
                 .required()
                 .action(KubernetesArgs.set((v, args) => args.copy(kubernetesVersion = Some(v)))),
 
+              opt[String]("kubernetes-namespace")
+                .text("Kubernetes namespace of the artefact to be generated")
+                .action(KubernetesArgs.set((v, args) => args.copy(kubernetesNamespace = Some(v)))),
+
               opt[Int]("kubernetes-deployment-nr-of-replicas")
                 .text("Sets the number of replicas set for Kubernetes deployment resource")
                 .validate(v => if (v >= 0) success else failure("Number of replicas must be zero or more"))

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/KubernetesArgs.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/KubernetesArgs.scala
@@ -67,6 +67,7 @@ object KubernetesArgs {
  */
 case class KubernetesArgs(
   kubernetesVersion: Option[Deployment.KubernetesVersion] = None,
+  kubernetesNamespace: Option[String] = None,
   deploymentArgs: DeploymentArgs = DeploymentArgs(),
   serviceArgs: ServiceArgs = ServiceArgs(),
   ingressArgs: IngressArgs = IngressArgs(),

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
@@ -252,7 +252,9 @@ object Deployment {
                   "app" -> appName.asJson,
                   "appVersionMajor" -> appVersionMajor.asJson,
                   "appVersionMajorMinor" -> appVersionMajorMinor.asJson,
-                  "appVersion" -> appVersion.asJson)),
+                  "appVersion" -> appVersion.asJson))
+                .deepmerge(
+                  annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> ns.asJson))),
               "spec" -> Json(
                 "replicas" -> noOfReplicas.asJson,
                 "selector" -> Json(

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Ingress.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Ingress.scala
@@ -75,7 +75,9 @@ object Ingress {
             "apiVersion" -> "extensions/v1beta1".asJson,
             "kind" -> "Ingress".asJson,
             "metadata" -> Json(
-              "name" -> appName.asJson).deepmerge(generateIngressAnnotations(ingressAnnotations)),
+              "name" -> appName.asJson).deepmerge(generateIngressAnnotations(ingressAnnotations))
+              .deepmerge(
+                annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> ns.asJson))),
             "spec" -> Json(
               "rules" -> encodeEndpoints(annotations.endpoints, pathAppend).asJson))))
       case _ =>

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Namespace.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Namespace.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.runtime.kubernetes
+
+import argonaut._
+import Argonaut._
+import com.lightbend.rp.reactivecli.annotations.Annotations
+
+import scala.util.{ Success, Try }
+
+object Namespace {
+  /**
+   * Builds [[Namespace]] resource.
+   */
+  def generate(annotations: Annotations): Try[Option[Namespace]] =
+    Success(
+      annotations.namespace.map { ns =>
+        Namespace(ns, Json(
+          "apiVersion" -> "v1".asJson,
+          "kind" -> "Namespace".asJson,
+          "metadata" -> Json(
+            "name" -> ns.asJson,
+            "labels" -> Json(
+              "name" -> ns.asJson))))
+      })
+
+}
+
+case class Namespace(name: String, payload: Json) extends GeneratedKubernetesResource {
+  val resourceType = "namespace"
+}

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
@@ -63,7 +63,9 @@ object Service {
               "metadata" -> Json(
                 "labels" -> Json(
                   "app" -> annotations.appName.asJson),
-                "name" -> annotations.appName.asJson),
+                "name" -> annotations.appName.asJson)
+                .deepmerge(
+                  annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> ns.asJson))),
               "spec" -> Json(
                 "clusterIP" -> clusterIp.getOrElse("None").asJson,
                 "ports" -> annotations.endpoints.asJson,

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -66,21 +66,23 @@ package object kubernetes extends LazyLogging {
 
       annotations = Annotations(label, generateDeploymentArgs)
 
-      deploymentJson <- Deployment.generate(
+      namespace <- Namespace.generate(annotations)
+
+      deployment <- Deployment.generate(
         annotations,
         kubernetesArgs.kubernetesVersion.get,
         generateDeploymentArgs.dockerImage.get,
         kubernetesArgs.deploymentArgs.imagePullPolicy,
         kubernetesArgs.deploymentArgs.numberOfReplicas)
 
-      serviceJson <- Service.generate(annotations, kubernetesArgs.serviceArgs.clusterIp)
+      service <- Service.generate(annotations, kubernetesArgs.serviceArgs.clusterIp)
 
-      ingressJson <- Ingress.generate(
+      ingress <- Ingress.generate(
         annotations,
         kubernetesArgs.ingressArgs.ingressAnnotations,
         kubernetesArgs.ingressArgs.pathAppend)
     } yield {
-      outputHandler(Seq(deploymentJson, serviceJson, ingressJson))
+      outputHandler(namespace.toSeq ++ Seq(deployment, service, ingress))
       Done
     }
   }

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
@@ -17,6 +17,7 @@
 package com.lightbend.rp.reactivecli.annotations
 
 import com.lightbend.rp.reactivecli.argparse.GenerateDeploymentArgs
+import com.lightbend.rp.reactivecli.argparse.kubernetes.KubernetesArgs
 import utest._
 
 import scala.collection.immutable.Seq
@@ -110,6 +111,7 @@ object AnnotationsTest extends TestSuite {
     "Annotations.apply" - {
       assert(
         Annotations(Map.empty, GenerateDeploymentArgs()) == Annotations(
+          namespace = None,
           appName = None,
           diskSpace = None,
           memory = None,
@@ -130,6 +132,7 @@ object AnnotationsTest extends TestSuite {
               "some.key" -> "test",
               "com.lightbend.rp.some-key" -> "test",
 
+              "com.lightbend.rp.namespace" -> "fonts",
               "com.lightbend.rp.app-name" -> "my-app",
               "com.lightbend.rp.version-major" -> "3",
               "com.lightbend.rp.version-minor" -> "2",
@@ -175,6 +178,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.endpoints.2.protocol" -> "udp",
               "com.lightbend.rp.endpoints.2.port" -> "1234"),
             GenerateDeploymentArgs()) == Annotations(
+              namespace = Some("fonts"),
               appName = Some("my-app"),
               diskSpace = Some(65536L),
               memory = Some(8192L),
@@ -200,6 +204,7 @@ object AnnotationsTest extends TestSuite {
         assert(
           Annotations(
             Map(
+              "com.lightbend.rp.namespace" -> "tom",
               "com.lightbend.rp.disk-space" -> "65536",
               "com.lightbend.rp.memory" -> "8192",
               "com.lightbend.rp.nr-of-cpus" -> "0.5",
@@ -212,7 +217,10 @@ object AnnotationsTest extends TestSuite {
               diskSpace = Some(2048),
               environmentVariables = Map(
                 "foo" -> "foo",
-                "hey" -> "there"))) == Annotations(
+                "hey" -> "there"),
+              targetRuntimeArgs = Some(KubernetesArgs(
+                kubernetesNamespace = Some("chirper"))))) == Annotations(
+              namespace = Some("chirper"),
               appName = None,
               diskSpace = Some(2048),
               memory = Some(1024),
@@ -238,6 +246,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.version-minor" -> "2",
               "com.lightbend.rp.version-patch" -> "1"),
             GenerateDeploymentArgs()) == Annotations(
+              namespace = None,
               appName = None,
               diskSpace = None,
               memory = None,
@@ -264,6 +273,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.endpoints.1.protocol" -> "tcp",
               "com.lightbend.rp.endpoints.1.port" -> "1234"),
             GenerateDeploymentArgs()) == Annotations(
+              namespace = None,
               appName = None,
               diskSpace = None,
               memory = None,
@@ -287,6 +297,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.endpoints.1.protocol" -> "tcp",
               "com.lightbend.rp.endpoints.1.port" -> "1234"),
             GenerateDeploymentArgs()) == Annotations(
+              namespace = None,
               appName = None,
               diskSpace = None,
               memory = None,
@@ -313,6 +324,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.readiness-check.args.0" -> "/usr/bin/env",
               "com.lightbend.rp.readiness-check.args.1" -> "bash"),
             GenerateDeploymentArgs()) == Annotations(
+              namespace = None,
               appName = None,
               diskSpace = None,
               memory = None,
@@ -340,6 +352,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.readiness-check.interval" -> "5",
               "com.lightbend.rp.readiness-check.path" -> "/hello"),
             GenerateDeploymentArgs()) == Annotations(
+              namespace = None,
               appName = None,
               diskSpace = None,
               memory = None,
@@ -365,6 +378,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.readiness-check.port" -> "1234",
               "com.lightbend.rp.readiness-check.interval" -> "5"),
             GenerateDeploymentArgs()) == Annotations(
+              namespace = None,
               appName = None,
               diskSpace = None,
               memory = None,

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -63,6 +63,7 @@ object InputArgsTest extends TestSuite {
                   "dockercloud/hello-world:1.0.0-SNAPSHOT",
                   "--target", "kubernetes",
                   "--kubernetes-version", "1.7",
+                  "--kubernetes-namespace", "chirper",
                   "--kubernetes-deployment-nr-of-replicas", "10",
                   "--kubernetes-deployment-image-pull-policy", "Always",
                   "--kubernetes-service-cluster-ip", "10.0.0.1",
@@ -87,6 +88,7 @@ object InputArgsTest extends TestSuite {
                       dockerImage = Some("dockercloud/hello-world:1.0.0-SNAPSHOT"),
                       targetRuntimeArgs = Some(KubernetesArgs(
                         kubernetesVersion = Some(KubernetesVersion(1, 7)),
+                        kubernetesNamespace = Some("chirper"),
                         output = KubernetesArgs.Output.SaveToFile(Paths.get("/tmp/foo")),
                         deploymentArgs = DeploymentArgs(
                           numberOfReplicas = 10,

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -32,6 +32,7 @@ object DeploymentJsonTest extends TestSuite {
     "ep3" -> UdpEndpoint(2, "ep3", 0, version = None))
 
   val annotations = Annotations(
+    namespace = Some("chirper"),
     appName = Some("friendimpl"),
     diskSpace = Some(65536L),
     memory = Some(8192L),
@@ -65,7 +66,8 @@ object DeploymentJsonTest extends TestSuite {
               |      "appVersionMajorMinor": "friendimpl-v3.2",
               |      "appVersion": "friendimpl-v3.2.1-SNAPSHOT"
               |    },
-              |    "name": "friendimpl-v3.2.1-SNAPSHOT"
+              |    "name": "friendimpl-v3.2.1-SNAPSHOT",
+              |    "namespace": "chirper"
               |  },
               |  "spec": {
               |    "replicas": 1,
@@ -331,7 +333,8 @@ object DeploymentJsonTest extends TestSuite {
               |      "appVersionMajorMinor": "friendimpl-v3.2",
               |      "appVersion": "friendimpl-v3.2.1-SNAPSHOT"
               |    },
-              |    "name": "friendimpl-v3.2.1-SNAPSHOT"
+              |    "name": "friendimpl-v3.2.1-SNAPSHOT",
+              |    "namespace": "chirper"
               |  },
               |  "spec": {
               |    "replicas": 1,
@@ -597,7 +600,8 @@ object DeploymentJsonTest extends TestSuite {
               |      "appVersionMajorMinor": "friendimpl-v3.2",
               |      "appVersion": "friendimpl-v3.2.1-SNAPSHOT"
               |    },
-              |    "name": "friendimpl-v3.2.1-SNAPSHOT"
+              |    "name": "friendimpl-v3.2.1-SNAPSHOT",
+              |    "namespace": "chirper"
               |  },
               |  "spec": {
               |    "replicas": 1,

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
@@ -25,6 +25,7 @@ import scala.collection.immutable.Seq
 
 object IngressJsonTest extends TestSuite {
   val annotations = Annotations(
+    namespace = Some("chirper"),
     appName = Some("friendimpl"),
     diskSpace = Some(65536L),
     memory = Some(8192L),
@@ -62,7 +63,8 @@ object IngressJsonTest extends TestSuite {
             |  "apiVersion" : "extensions/v1beta1",
             |  "kind" : "Ingress",
             |  "metadata" : {
-            |    "name" : "friendimpl"
+            |    "name" : "friendimpl",
+            |    "namespace": "chirper"
             |  },
             |  "spec" : {
             |    "rules" : [
@@ -157,7 +159,8 @@ object IngressJsonTest extends TestSuite {
             |    "name" : "friendimpl",
             |    "annotations" : {
             |      "kubernetes.io/ingress.class" : "istio"
-            |    }
+            |    },
+            |    "namespace": "chirper"
             |  },
             |  "spec" : {
             |    "rules" : [

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/NamespaceJsonTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/NamespaceJsonTest.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.runtime.kubernetes
+
+import argonaut._
+import Argonaut._
+import scala.collection.immutable.Seq
+import com.lightbend.rp.reactivecli.annotations.Annotations
+import utest._
+
+object NamespaceJsonTest extends TestSuite {
+
+  val tests = this{
+    "json serialization" - {
+      val annotations = new Annotations(
+        namespace = None,
+        appName = None,
+        diskSpace = None,
+        memory = None,
+        nrOfCpus = None,
+        endpoints = Map.empty,
+        secrets = Seq.empty,
+        volumes = Map.empty,
+        privileged = false,
+        healthCheck = None,
+        readinessCheck = None,
+        environmentVariables = Map.empty,
+        version = None)
+
+      "namespace present" - {
+        val result = Namespace.generate(annotations.copy(namespace = Some("chirper")))
+
+        assert(result.isSuccess)
+
+        val expectedJson =
+          """
+            |{
+            |  "apiVersion": "v1",
+            |  "kind": "Namespace",
+            |  "metadata": {
+            |    "name": "chirper",
+            |    "labels": {
+            |      "name": "chirper"
+            |    }
+            |  }
+            |}
+          """.stripMargin.parse.right.get
+        assert(result.get.get == Namespace("chirper", expectedJson))
+      }
+
+      "namespace not present" - {
+        val result = Namespace.generate(annotations.copy(namespace = None))
+
+        assert(result.isSuccess)
+        assert(result.get.isEmpty)
+      }
+    }
+  }
+}

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
@@ -24,9 +24,9 @@ import com.lightbend.rp.reactivecli.annotations._
 import scala.collection.immutable.Seq
 
 object ServiceJsonTest extends TestSuite {
-  import Service._
 
   val annotations = Annotations(
+    namespace = Some("chirper"),
     appName = Some("friendimpl"),
     diskSpace = Some(65536L),
     memory = Some(8192L),
@@ -57,7 +57,8 @@ object ServiceJsonTest extends TestSuite {
               |    "labels": {
               |      "app": "friendimpl"
               |    },
-              |    "name": "friendimpl"
+              |    "name": "friendimpl",
+              |    "namespace": "chirper"
               |  },
               |  "spec": {
               |    "clusterIP": "None",
@@ -89,7 +90,8 @@ object ServiceJsonTest extends TestSuite {
               |    "labels": {
               |      "app": "friendimpl"
               |    },
-              |    "name": "friendimpl"
+              |    "name": "friendimpl",
+              |    "namespace": "chirper"
               |  },
               |  "spec": {
               |    "clusterIP": "10.0.0.5",


### PR DESCRIPTION
Reads namespace from the Docker labels.

If present, generates the `Namespace` kubernetes resources, and adds the `namespace` metadata to existing `Deployment`, `Service`, and `Ingress` resource.

Allows operator to specify a namespace from input argument, which overrides the namespace from the Docker labels if present.