### PR TITLE
Implement support for reading docker credentials from a file

### DIFF
--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerCredentials.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerCredentials.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.docker
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path }
+import scala.collection.immutable.Seq
+
+case class DockerCredentials(registry: String, username: String, password: String)
+
+/**
+ * Parses a file for credentials
+ */
+object DockerCredentials {
+  private val Registry = "registry"
+  private val Username = "username"
+  private val Password = "password"
+
+  def parse(path: Path): Seq[DockerCredentials] =
+    decode(new String(Files.readAllBytes(path), StandardCharsets.UTF_8))
+
+  /**
+   * Decodes a Docker credential file. This is a simplistic format with a number of
+   * key = value pairs (white-space trimmed) separated by "\n" characters.
+   *
+   * Recognized keys: registry, username, password
+   *
+   * Example file:
+   *
+   * registry = lightbend-docker-registry.bintray.io
+   * username = hello
+   * password = there
+   *
+   * registry = registry.hub.docker.com
+   * username = foo
+   * password = bar
+   *
+   * yields
+   *
+   * Seq(
+   *   DockerCredentials("lightbend-docker-registry.bintray.io", "hello", "there"),
+   *   DockerCredentials("registry.hub.docker.com", "foo", "bar"))
+   */
+  def decode(content: String): Seq[DockerCredentials] =
+    lines(content)
+      .foldLeft(List.empty[DockerCredentials]) {
+        case (accum, next) =>
+          val modify =
+            accum.nonEmpty && (
+              accum.head.registry.isEmpty ||
+              accum.head.username.isEmpty ||
+              accum.head.password.isEmpty)
+
+          parseLine(next) match {
+            case (Registry, registry) =>
+              if (modify)
+                accum.head.copy(registry = registry) :: accum.tail
+              else
+                DockerCredentials(registry, "", "") :: accum
+
+            case (Username, username) =>
+              if (modify)
+                accum.head.copy(username = username) :: accum.tail
+              else
+                DockerCredentials("", username, "") :: accum
+
+            case (Password, password) =>
+              if (modify)
+                accum.head.copy(password = password) :: accum.tail
+              else
+                DockerCredentials("", "", password) :: accum
+
+            case _ =>
+              accum
+          }
+      }
+      .reverse
+
+  private[docker] def parseLine(line: String): (String, String) = {
+    val parts = line.split("=", 2).lift
+
+    parts(0).map(_.trim).getOrElse("") -> parts(1).map(_.trim).getOrElse("")
+  }
+
+  private[docker] def lines(content: String): Array[String] =
+    content
+      .replaceAllLiterally("\r\n", "\n")
+      .replaceAllLiterally("\r", "")
+      .split('\n')
+}

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
@@ -83,6 +83,11 @@ object DockerRegistry extends LazyLogging {
       config <- getDecoded[Config](blob._1)
     } yield config -> blob._2
 
+  def getRegistry(image: String): Option[String] =
+    parseImageUri(image)
+      .toOption
+      .map(_.url)
+
   private def getManifest(http: HttpExchange, credentials: Option[HttpRequest.BasicAuth], useHttps: Boolean, validateTls: Boolean)(uri: String, token: Option[HttpRequest.BearerToken]): Try[(Manifest, Option[HttpRequest.BearerToken])] =
     for {
       i <- parseImageUri(uri)

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerCredentialsTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerCredentialsTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.docker
+
+import scala.collection.immutable.Seq
+import utest._
+
+object DockerCredentialsTest extends TestSuite {
+  val tests = this{
+    "Parse Credentials" - {
+      val result = DockerCredentials.decode(
+        """|registry = lightbend-docker-registry.bintray.io
+           |username=hello
+           |password =      there
+           |
+           |reg=what
+           |
+           |registry= registry.hub.docker.com
+           |password = bar
+           |username    = foo
+           |
+           |registry= 1.hub.docker.com
+           |password = what
+           |registry = 2.hub.docker.com
+           |username = ok
+           |""".stripMargin)
+
+      val expected = Seq(
+        DockerCredentials("lightbend-docker-registry.bintray.io", "hello", "there"),
+        DockerCredentials("registry.hub.docker.com", "foo", "bar"),
+        DockerCredentials("2.hub.docker.com", "ok", "what"))
+
+      assert(result == expected)
+    }
+  }
+}


### PR DESCRIPTION
This adds a feature to parse a file in `~/.lightbend/docker.credentials` for reading Docker credentials.

Example file:

```
registry = lightbend-docker-registry.bintray.io
username = hello
password = there

registry = registry.hub.docker.com
username = foo
password = bar
```