### PR TITLE
Implement support for canary, rolling, and blue-green deployment types

### DIFF
--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -23,7 +23,6 @@ import com.lightbend.rp.reactivecli.runtime.kubernetes
 import libhttpsimple.{ HttpRequest, LibHttpSimple }
 import libhttpsimple.LibHttpSimple.HttpExchange
 import java.nio.file.{ Files, Path, Paths }
-
 import scala.annotation.tailrec
 import scala.util.Try
 import slogging._
@@ -58,7 +57,7 @@ object Main extends LazyLogging {
             case VersionArgs =>
               System.out.println(s"rp (Reactive CLI) ${ProgramVersion.current}")
 
-            case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, Some(kubernetesArgs: KubernetesArgs), _, _, _, _, _) =>
+            case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, _, Some(kubernetesArgs: KubernetesArgs), _, _, _, _, _) =>
               implicit val httpSettings: LibHttpSimple.Settings =
                 inputArgs.tlsCacertsPath.fold(LibHttpSimple.defaultSettings)(v => LibHttpSimple.defaultSettings.copy(tlsCacertsPath = Some(v)))
 

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -46,10 +46,24 @@ object GenerateDeploymentArgs {
     }
 }
 
+object DeploymentType {
+  val Canary = "canary"
+  val BlueGreen = "blue-green"
+  val Rolling = "rolling"
+  val All = Seq(Canary, BlueGreen, Rolling)
+}
+
+sealed trait DeploymentType
+
+case object CanaryDeploymentType extends DeploymentType
+case object BlueGreenDeploymentType extends DeploymentType
+case object RollingDeploymentType extends DeploymentType
+
 /**
  * Represents the input argument for `generate-deployment` command.
  */
 case class GenerateDeploymentArgs(
+  deploymentType: DeploymentType = CanaryDeploymentType,
   dockerImage: Option[String] = None,
   environmentVariables: Map[String, String] = Map.empty,
   nrOfCpus: Option[Double] = None,

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Ingress.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Ingress.scala
@@ -69,7 +69,8 @@ object Ingress {
    */
   def generate(annotations: Annotations, apiVersion: String, ingressAnnotations: Map[String, String], pathAppend: Option[String]): Try[Option[Ingress]] =
     annotations.appName match {
-      case Some(appName) =>
+      case Some(rawAppName) =>
+        val appName = serviceName(rawAppName)
         val encodedEndpoints = encodeEndpoints(appName, annotations.endpoints, pathAppend)
 
         if (encodedEndpoints.isEmpty)
@@ -103,7 +104,7 @@ object Ingress {
           .reduce(_.deepmerge(_)))
 
   private def generateNamespaceAnnotation(namespace: Option[String]): Json =
-    namespace.fold(jEmptyObject)(ns => Json("namespace" -> ns.asJson))
+    namespace.fold(jEmptyObject)(ns => Json("namespace" -> serviceName(ns).asJson))
 }
 
 /**

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Namespace.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Namespace.scala
@@ -27,7 +27,9 @@ object Namespace {
    */
   def generate(annotations: Annotations, apiVersion: String): Try[Option[Namespace]] =
     Success(
-      annotations.namespace.map { ns =>
+      annotations.namespace.map { rawNs =>
+        val ns = serviceName(rawNs)
+
         Namespace(ns, Json(
           "apiVersion" -> apiVersion.asJson,
           "kind" -> "Namespace".asJson,

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -16,17 +16,15 @@
 
 package com.lightbend.rp.reactivecli.runtime
 
-import java.io.PrintStream
-import java.nio.file.{ Files, Path }
-
 import argonaut.PrettyParams
 import com.lightbend.rp.reactivecli.annotations.Annotations
 import com.lightbend.rp.reactivecli.argparse.GenerateDeploymentArgs
 import com.lightbend.rp.reactivecli.argparse.kubernetes.KubernetesArgs
 import com.lightbend.rp.reactivecli.docker.Config
-import slogging.LazyLogging
-
+import java.io.PrintStream
+import java.nio.file.{ Files, Path }
 import scala.util.{ Failure, Success, Try }
+import slogging.LazyLogging
 
 package object kubernetes extends LazyLogging {
   /**
@@ -73,20 +71,20 @@ package object kubernetes extends LazyLogging {
         generateDeploymentArgs.dockerImage.get,
         kubernetesArgs.podControllerArgs.imagePullPolicy,
         kubernetesArgs.podControllerArgs.numberOfReplicas,
-        generateDeploymentArgs.externalServices)
+        generateDeploymentArgs.externalServices,
+        generateDeploymentArgs.deploymentType)
 
-      service <- Service.generate(annotations, kubernetesArgs.serviceArgs.apiVersion, kubernetesArgs.serviceArgs.clusterIp)
+      service <- Service.generate(annotations, kubernetesArgs.serviceArgs.apiVersion, kubernetesArgs.serviceArgs.clusterIp, generateDeploymentArgs.deploymentType)
 
       ingress <- Ingress.generate(
         annotations,
         kubernetesArgs.ingressArgs.apiVersion,
         kubernetesArgs.ingressArgs.ingressAnnotations,
         kubernetesArgs.ingressArgs.pathAppend)
-    } yield
-      namespace.filter(_ => kubernetesArgs.shouldGenerateNamespaces).toSeq ++
-        Seq(deployment).filter(_ => kubernetesArgs.shouldGeneratePodControllers) ++
-        service.toSeq.filter(_ => kubernetesArgs.shouldGenerateServices) ++
-        ingress.toSeq.filter(_ => kubernetesArgs.shouldGenerateIngress)
+    } yield namespace.filter(_ => kubernetesArgs.shouldGenerateNamespaces).toSeq ++
+      Seq(deployment).filter(_ => kubernetesArgs.shouldGeneratePodControllers) ++
+      service.toSeq.filter(_ => kubernetesArgs.shouldGenerateServices) ++
+      ingress.toSeq.filter(_ => kubernetesArgs.shouldGenerateIngress)
   }
 
   /**

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -79,7 +79,8 @@ object InputArgsTest extends TestSuite {
                   "--generate-ingress",
                   "--generate-namespaces",
                   "--generate-pod-controllers",
-                  "--generate-services"),
+                  "--generate-services",
+                  "--deployment-type", "rolling"),
                 InputArgs.default)
 
               assert(
@@ -88,6 +89,7 @@ object InputArgsTest extends TestSuite {
                     logLevel = LogLevel.DEBUG,
                     tlsCacertsPath = Some(mockCacerts),
                     commandArgs = Some(GenerateDeploymentArgs(
+                      deploymentType = RollingDeploymentType,
                       dockerImage = Some("dockercloud/hello-world:1.0.0-SNAPSHOT"),
                       targetRuntimeArgs = Some(KubernetesArgs(
                         generateIngress = true,


### PR DESCRIPTION
This PR implements `--deployment-type` with 3 values, `canary`, `rolling`, and `blue-green`. These slightly tweak the resources generated to accommodate such deployments.

Defaults to `canary` as that was the type we were generating before.

For blue green, the main change is that the `Service` selector is on `appVersion` instead of `appName`.

For rolling, the main change is that the `Deployment` name is `appName` instead of `appVersion`.