### PR TITLE
Use Kubernetes API for bootstrap discovery method

### DIFF
--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
@@ -81,7 +81,7 @@ object Deployment {
       else
         Map(
           "RP_JAVA_OPTS" -> LiteralEnvironmentVariable(
-            s"-Dakka.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas"))
+            s"-Dakka.cluster.bootstrap.contact-point-discovery.discovery-method=akka.discovery.reactive-lib-kubernetes -Dakka.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas"))
 
     private[kubernetes] def configEnvs(config: Option[String]): Map[String, EnvironmentVariable] =
       config

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -125,7 +125,7 @@ object DeploymentJsonTest extends TestSuite {
               |            },
               |            {
               |              "name": "RP_JAVA_OPTS",
-              |              "value": "-Dconfig.resource=my-config.conf -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1"
+              |              "value": "-Dakka.cluster.bootstrap.contact-point-discovery.discovery-method=akka.discovery.reactive-lib-kubernetes -Dconfig.resource=my-config.conf -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1"
               |            },
               |            {
               |              "name": "RP_ENDPOINTS",


### PR DESCRIPTION
Complements https://github.com/lightbend/reactive-lib/pull/27 - see that PR plus this card for more context: https://trello.com/c/FatlTAOj/983-support-healthcheck-which-works-with-akka-cluster-management

This adjusts the CLI configuration to use the Kubernetes API discovery method. By doing this in the CLI and keeping both methods around, we are a bit more flexible and can easily allow the user to override it via `--env JAVA_OPTS`.