### PR TITLE
YAML

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argonaut/YamlRenderer.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argonaut/YamlRenderer.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.argonaut
+
+import argonaut.Argonaut._
+import argonaut._
+
+object YamlRenderer {
+  private val Indent = "  "
+  private val IndentArray = "- "
+
+  def render(j: Json): String = {
+    def string(string: JsonString): String =
+      if (needsQuotes(string))
+        jString(string).nospaces
+      else
+        string
+
+    def bool(b: Boolean): String =
+      if (b) "true" else "false"
+
+    def `null`: String =
+      "null"
+
+    def number(number: JsonNumber): String =
+      number.asJson.nospaces
+
+    def nonEmptyArrayOrObject(j: Json): Boolean =
+      (j.isArray && j.array.get.nonEmpty) || (j.isObject && j.obj.get.isNotEmpty)
+
+    def array(array: JsonArray, level: Int): String =
+      if (array.isEmpty)
+        "[]"
+      else
+        array
+          .map { element =>
+            val rendered = render(element, level + 1)
+
+            if (nonEmptyArrayOrObject(element)) {
+              val initialSpaces = spaces(level + 1)
+              val replacement = spaces(level) + IndentArray
+              val fixed = rendered.replaceFirst(initialSpaces, replacement)
+
+              fixed
+            } else {
+              spaces(level) + IndentArray + rendered
+            }
+          }
+          .mkString("\n")
+
+    def obj(obj: JsonObject, level: Int): String =
+      if (obj.isEmpty)
+        "{}"
+      else
+        obj
+          .toList
+          .map { case (field, value) =>
+            val renderedField = string(field)
+            val rendered = render(value, level + 1)
+            val separator =
+              if (nonEmptyArrayOrObject(value))
+                ":\n"
+              else
+                ": "
+
+            spaces(level) + renderedField + separator + rendered
+          }
+          .mkString("\n")
+
+    def render(json: Json, level: Int): String = {
+      if (json.isString)
+        string(json.string.get)
+      else if (json.isBool)
+        bool(json.bool.get)
+      else if (json.isNull)
+        `null`
+      else if (json.isNumber)
+        number(json.number.get)
+      else if (json.isArray)
+        array(json.array.get, level)
+      else if (json.isObject)
+        obj(json.obj.get, level)
+      else
+        throw new IllegalArgumentException(s"Unexpected state for $json")
+    }
+
+    render(json = j, level = 0)
+  }
+
+  private def spaces(level: Int): String = Indent * level
+
+  private def needsQuotes(string: String) =
+    string.isEmpty || string.trim != string || !string.matches("^[A-Za-z][A-Za-z0-9 ]*$")
+}

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp.reactivecli
-package docker
+package com.lightbend.rp.reactivecli.docker
 
 import argonaut._
 import com.lightbend.rp.reactivecli.concurrent._

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argonaut/YamlRendererTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argonaut/YamlRendererTest.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.argonaut
+
+import argonaut._
+import utest._
+
+import Argonaut._
+
+object YamlRendererTest extends TestSuite {
+  import YamlRenderer.render
+
+  val tests = this {
+    def equal[A, B](a: A, b: B) = assert(a == b)
+
+    "render" - {
+      "empty arrays" - equal(render(jEmptyArray), "[]")
+
+      "empty objects" - equal(render(jEmptyObject), "{}")
+
+      "empty string" - equal(render(jEmptyString), "\"\"")
+
+      "zero" - equal(render(jZero), "0")
+
+      "null" - equal(render(jNull), "null")
+
+      "true" - equal(render(jTrue), "true")
+
+      "false" - equal(render(jFalse), "false")
+
+      "numeric arrays" - equal(
+        render(jArrayElements(jNumber(1), jNumber(2), jNumber(3))),
+
+        """|- 1
+           |- 2
+           |- 3""".stripMargin
+      )
+
+      "numeric string" - equal(render(jString("12345")), "\"12345\"")
+
+      "simple string" - equal(render(jString("hello world")), "hello world")
+
+      "complex string" - equal(render(jString("hello \"world!\"")), "\"hello \\\"world!\\\"\"")
+
+      "simple object" - equal(
+        render(jObjectFields("name" -> jString("jason"), "age" -> jNumber(100))),
+        "name: jason\nage: 100"
+      )
+
+      "array of objects" - equal(
+        render(
+          jArrayElements(
+            jObjectFields("name" -> jString("john!"), "age" -> jNumber(100), "present?" -> jFalse),
+            jObjectFields("name" -> jString("jessica"), "age" -> jNumber(101), "present?" -> jTrue)
+          )
+        ),
+
+        """|- name: "john!"
+           |  age: 100
+           |  "present?": false
+           |- name: jessica
+           |  age: 101
+           |  "present?": true""".stripMargin
+      )
+
+      "object containing array of objects" - equal(
+        render(
+          jObjectFields("people" -> jArrayElements(
+            jObjectFields("name" -> jString("john"), "age" -> jNumber(100)),
+            jObjectFields("name" -> jString("jessica"), "age" -> jNumber(101))
+          ))
+        ),
+
+        """|people:
+           |  - name: john
+           |    age: 100
+           |  - name: jessica
+           |    age: 101""".stripMargin
+      )
+
+      "nested arrays" - equal(
+        render(
+          jArrayElements(
+            jArrayElements(jNumber(1), jNumber(2), jNumber(3)),
+            jArrayElements(jNumber(4), jNumber(5), jNumber(6)),
+            jArrayElements(jNumber(7), jNumber(8), jNumber(9))
+          )
+        ),
+
+
+        """|- - 1
+           |  - 2
+           |  - 3
+           |- - 4
+           |  - 5
+           |  - 6
+           |- - 7
+           |  - 8
+           |  - 9""".stripMargin
+      )
+
+      "nested objects" - equal(
+        render(
+          jObjectFields("spec" -> jObjectFields(
+            "template" -> jObjectFields(
+              "spec" -> jObjectFields(
+                "one" -> jNumber(1),
+                "two" -> jNumber(2),
+                "three" -> jObjectFields(
+                  "a" -> jArrayElements(jFalse),
+                  "b" -> jArrayElements(jTrue)
+                )
+              )
+            )
+          ))
+        ),
+
+        """|spec:
+           |  template:
+           |    spec:
+           |      one: 1
+           |      two: 2
+           |      three:
+           |        a:
+           |          - false
+           |        b:
+           |          - true""".stripMargin
+      )
+    }
+  }
+}

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
@@ -513,20 +513,16 @@ object KubernetesPackageTest extends TestSuite {
           Service("svc1", Json("key2" -> "value2".asJson), None))
         withTempDir { testDir =>
           handleGeneratedResources(KubernetesArgs.Output.SaveToFile(testDir))(generatedResources).map { _ =>
-            val deploymentFile = pathFor(testDir, "deployment-dep1.json")
+            val deploymentFile = pathFor(testDir, "deployment-dep1.yml")
             val deploymentFileContent = readFile(deploymentFile)
             val deploymentFileExpected =
-              """{
-                |  "key1" : "value1"
-                |}""".stripMargin
+              """key1: value1""".stripMargin
             assert(deploymentFileContent == deploymentFileExpected)
 
-            val serviceFile = pathFor(testDir, "service-svc1.json")
+            val serviceFile = pathFor(testDir, "service-svc1.yml")
             val serviceFileContent = readFile(serviceFile)
             val serviceFileExpected =
-              """{
-                |  "key2" : "value2"
-                |}""".stripMargin
+              """key2: value2""".stripMargin
             assert(serviceFileContent == serviceFileExpected)
           }
         }
@@ -545,15 +541,11 @@ object KubernetesPackageTest extends TestSuite {
 
           val generatedText = new String(output.toByteArray)
           val expectedText =
-            """---
-              |{
-              |  "key1" : "value1"
-              |}
-              |---
-              |{
-              |  "key2" : "value2"
-              |}
-              |""".stripMargin
+            """|---
+               |key1: value1
+               |---
+               |key2: value2
+               |""".stripMargin
           assert(generatedText == expectedText)
         }
       }


### PR DESCRIPTION
Adds a fairly conservative YAML renderer. Since YAML is a superset of JSON, we can defer to the underlying Argonaut JSON rendering for most things and only output YAML when we're 100% sure it's safe.

I didn't add a flag for output as YAML is the overwhelming default in K8s land, and technically we only over outputted YAML anyways because of the document separator (`---`).