### PR TITLE
Remove parallel builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ the ones already created.
 
 ```sbt "build ubuntu-16-04"```
 
-#### Building every distribution in parallel
+#### Building every distribution
 
 ```sbt buildAll```
 

--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,8 @@ lazy val root = project
     ),
 
     build in Compile := {
+      BuildInfo.initialize(baseDirectory.value)
+
       for {
         name <- spaceDelimited("<arg>").parsed.toVector
         result <- BuildInfo.Builds.find(_.name == name) match {
@@ -94,9 +96,10 @@ lazy val root = project
     },
 
     buildAll in Compile := {
+      BuildInfo.initialize(baseDirectory.value)
+
       for {
-        g <- BuildInfo.Builds.grouped(Properties.concurrentBuilds)
-        b <- g.par
+        b <- BuildInfo.Builds
       } yield {
         val stage = target.value / "stage" / b.name
 

--- a/project/Properties.scala
+++ b/project/Properties.scala
@@ -1,5 +1,4 @@
 object Properties {
-  val concurrentBuilds = Option(System.getProperty("build.concurrentBuilds")).map(_.toInt).getOrElse(2)
   val dynamicLinker = Option(System.getProperty("build.dynamicLinker"))
   val nativeMode = System.getProperty("build.nativeMode", "debug")
 }


### PR DESCRIPTION
This simplifies the build pipeline by removing parallel builds. We only need to copy ivy cache once. This should fix some contention issues I occasionally see during releases -- sometimes the kernel fails to cleanup a container and this kills the build pipeline.