### PR TITLE
Fix kubectl timeout

### DIFF
--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/KubernetesArgs.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/KubernetesArgs.scala
@@ -41,12 +41,13 @@ object KubernetesArgs {
    */
   sealed trait Output
 
-  val DefaultNamespaceApiVersion: String = kubectl.findApi("v1")
   val DefaultNumberOfReplicas: Int = 1
   val DefaultImagePullPolicy: Deployment.ImagePullPolicy.Value = Deployment.ImagePullPolicy.IfNotPresent
-  val DefaultIngressApiVersion: String = kubectl.findApi("extensions/v1beta1")
-  val DefaultPodControllerApiVersion: String = kubectl.findApi("apps/v1beta2", "apps/v1beta1")
-  val DefaultServiceApiVersion: String = kubectl.findApi("v1")
+
+  lazy val DefaultNamespaceApiVersion: String = kubectl.findApi("v1")
+  lazy val DefaultIngressApiVersion: String = kubectl.findApi("extensions/v1beta1")
+  lazy val DefaultPodControllerApiVersion: String = kubectl.findApi("apps/v1beta2", "apps/v1beta1")
+  lazy val DefaultServiceApiVersion: String = kubectl.findApi("v1")
 
   /**
    * Convenience method to set the [[KubernetesArgs]] values when parsing the complete user input.

--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/process/kubectl.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/process/kubectl.scala
@@ -21,7 +21,7 @@ import slogging._
 
 object kubectl extends LazyLogging {
   lazy val apiVersions: Seq[String] = {
-    val (code, output) = exec("kubectl", "api-versions")
+    val (code, output) = exec("kubectl", "api-versions", "--request-timeout=1s")
 
     if (code == 0) {
       output


### PR DESCRIPTION
This fixes a couple things:

1) calls to kubectl.findApi should be lazy
2) Specify a default API timeout for the `kubectl api-versions` to 1 second. This makes things work more reasonably when e.g. the Minikube is down after a restart.