### PR TITLE
Implement support for separate apps joining same cluster

### DIFF
--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/annotations/Annotations.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/annotations/Annotations.scala
@@ -41,7 +41,8 @@ case class Annotations(
   readinessCheck: Option[Check],
   environmentVariables: Map[String, EnvironmentVariable],
   version: Option[String],
-  modules: Set[String]) {
+  modules: Set[String],
+  akkaClusterBootstrapSystemName: Option[String]) {
 
   def appNameValidation: ValidationNel[String, String] =
     appName.fold[ValidationNel[String, String]]("Docker label \"com.lightbend.rp.app-name\" must be defined".failureNel)(_.successNel)
@@ -91,7 +92,8 @@ object Annotations {
       environmentVariables = environmentVariables(selectArray(labels, ns("environment-variables"))) ++
         args.environmentVariables.mapValues(LiteralEnvironmentVariable.apply),
       version = appVersion,
-      modules = appModules(selectSubset(labels, ns("modules"))))
+      modules = appModules(selectSubset(labels, ns("modules"))),
+      akkaClusterBootstrapSystemName = akkaClusterBootstrapSystemName(labels))
   }
 
   private[annotations] def namespace(args: GenerateDeploymentArgs): Option[String] =
@@ -125,6 +127,10 @@ object Annotations {
 
     parsed.toSet
   }
+
+  private[annotations] def akkaClusterBootstrapSystemName(labels: Map[String, String]): Option[String] =
+    labels
+      .get(ns("akka-cluster-bootstrap", "system-name"))
 
   private[annotations] def diskSpace(labels: Map[String, String]): Option[Long] =
     labels

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
@@ -126,7 +126,8 @@ object AnnotationsTest extends TestSuite {
           readinessCheck = None,
           environmentVariables = Map.empty,
           version = None,
-          modules = Set.empty))
+          modules = Set.empty,
+          akkaClusterBootstrapSystemName = None))
 
       "all options (except checks)" - {
         assert(
@@ -179,7 +180,8 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.endpoints.2.protocol" -> "udp",
               "com.lightbend.rp.endpoints.2.port" -> "1234",
               "com.lightbend.rp.modules.common.enabled" -> "true",
-              "com.lightbend.rp.modules.another-one.enabled" -> "false"),
+              "com.lightbend.rp.modules.another-one.enabled" -> "false",
+              "com.lightbend.rp.akka-cluster-bootstrap.system-name" -> "test"),
             GenerateDeploymentArgs()) == Annotations(
               namespace = None,
               appName = Some("my-app"),
@@ -203,7 +205,8 @@ object AnnotationsTest extends TestSuite {
                 "testing2" -> kubernetes.ConfigMapEnvironmentVariable("mymap", "mykey"),
                 "testing3" -> kubernetes.FieldRefEnvironmentVariable("metadata.name")),
               version = Some("3.2.1-SNAPSHOT"),
-              modules = Set("common")))
+              modules = Set("common"),
+              akkaClusterBootstrapSystemName = Some("test")))
       }
 
       "argument overrides" - {
@@ -242,7 +245,8 @@ object AnnotationsTest extends TestSuite {
                 "foo" -> LiteralEnvironmentVariable("foo"),
                 "hey" -> LiteralEnvironmentVariable("there")),
               version = None,
-              modules = Set.empty))
+              modules = Set.empty,
+              akkaClusterBootstrapSystemName = None))
 
       }
 
@@ -267,7 +271,8 @@ object AnnotationsTest extends TestSuite {
               readinessCheck = None,
               environmentVariables = Map.empty,
               version = Some("3.2.1"),
-              modules = Set.empty))
+              modules = Set.empty,
+              akkaClusterBootstrapSystemName = None))
       }
 
       "version (argument override)" - {
@@ -290,7 +295,8 @@ object AnnotationsTest extends TestSuite {
               readinessCheck = None,
               environmentVariables = Map.empty,
               version = Some("2.1.3"),
-              modules = Set.empty))
+              modules = Set.empty,
+              akkaClusterBootstrapSystemName = None))
       }
 
       "endpoint (no version)" - {
@@ -319,7 +325,8 @@ object AnnotationsTest extends TestSuite {
               readinessCheck = None,
               environmentVariables = Map.empty,
               version = Some("3.2.1"),
-              modules = Set.empty))
+              modules = Set.empty,
+              akkaClusterBootstrapSystemName = None))
       }
 
       "endpoint (no version and no app version)" - {
@@ -346,7 +353,8 @@ object AnnotationsTest extends TestSuite {
               readinessCheck = None,
               environmentVariables = Map.empty,
               version = None,
-              modules = Set.empty))
+              modules = Set.empty,
+              akkaClusterBootstrapSystemName = None))
       }
 
       "CommandCheck" - {
@@ -375,7 +383,8 @@ object AnnotationsTest extends TestSuite {
               readinessCheck = Some(CommandCheck("/usr/bin/env", "bash")),
               environmentVariables = Map.empty,
               version = None,
-              modules = Set.empty))
+              modules = Set.empty,
+              akkaClusterBootstrapSystemName = None))
       }
 
       "HttpCheck" - {
@@ -406,7 +415,8 @@ object AnnotationsTest extends TestSuite {
               readinessCheck = Some(HttpCheck(Check.PortNumber(1234), 5, "/hello")),
               environmentVariables = Map.empty,
               version = None,
-              modules = Set.empty))
+              modules = Set.empty,
+              akkaClusterBootstrapSystemName = None))
       }
 
       "TcpCheck" - {
@@ -435,7 +445,8 @@ object AnnotationsTest extends TestSuite {
               readinessCheck = Some(TcpCheck(Check.PortNumber(1234), 5)),
               environmentVariables = Map.empty,
               version = None,
-              modules = Set.empty))
+              modules = Set.empty,
+              akkaClusterBootstrapSystemName = None))
       }
     }
   }

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -50,7 +50,8 @@ object DeploymentJsonTest extends TestSuite {
     environmentVariables = Map(
       "testing1" -> LiteralEnvironmentVariable("testingvalue1")),
     version = Some("3.2.1-SNAPSHOT"),
-    modules = Set.empty)
+    modules = Set.empty,
+    akkaClusterBootstrapSystemName = None)
 
   val imageName = "my-repo/my-image"
 

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
@@ -50,7 +50,8 @@ object IngressJsonTest extends TestSuite {
     environmentVariables = Map(
       "testing1" -> LiteralEnvironmentVariable("testingvalue1")),
     version = Some("3.2.1-SNAPSHOT"),
-    modules = Set.empty)
+    modules = Set.empty,
+    akkaClusterBootstrapSystemName = None)
 
   val tests = this{
     "json serialization" - {

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/NamespaceJsonTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/NamespaceJsonTest.scala
@@ -42,7 +42,8 @@ object NamespaceJsonTest extends TestSuite {
         readinessCheck = None,
         environmentVariables = Map.empty,
         version = None,
-        modules = Set.empty)
+        modules = Set.empty,
+        akkaClusterBootstrapSystemName = None)
 
       "namespace present" - {
         val result = Namespace.generate(annotations.copy(namespace = Some("chirper")), "v1", None)

--- a/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
+++ b/cli/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
@@ -45,7 +45,8 @@ object ServiceJsonTest extends TestSuite {
     environmentVariables = Map(
       "testing1" -> LiteralEnvironmentVariable("testingvalue1")),
     version = Some("3.2.1-SNAPSHOT"),
-    modules = Set.empty)
+    modules = Set.empty,
+    akkaClusterBootstrapSystemName = None)
 
   val tests = this{
     "json serialization" - {


### PR DESCRIPTION
This complements https://github.com/lightbend/sbt-reactive-app/pull/62/files and allows different apps to join the same cluster by specifying `akkaClusterBootstrapSystemName` in their SBT build.

Manual test was completed successfully:

Given sbt config:

```sbt
enableAkkaClusterBootstrap := Some(true)

akkaClusterBootstrapSystemName := Some("my-system")
```

The following resources deployment was generated (note RP_JAVA_OPTS and labels sections):

```json
{
  "apiVersion" : "apps/v1beta2",
  "kind" : "Deployment",
  "metadata" : {
    "name" : "akka-cluster-tooling-example-v0-1-0",
    "labels" : {
      "appName" : "akka-cluster-tooling-example",
      "appNameVersion" : "akka-cluster-tooling-example-v0-1-0",
      "actorSystemName" : "my-system"
    }
  },
  "spec" : {
    "replicas" : 2,
    "selector" : {
      "matchLabels" : {
        "appNameVersion" : "akka-cluster-tooling-example-v0-1-0"
      }
    },
    "template" : {
      "metadata" : {
        "labels" : {
          "appName" : "akka-cluster-tooling-example",
          "appNameVersion" : "akka-cluster-tooling-example-v0-1-0",
          "actorSystemName" : "my-system"
        }
      },
      "spec" : {
        "containers" : [
          {
            "name" : "akka-cluster-tooling-example",
            "image" : "akka-cluster-tooling-example/akka-cluster-tooling-example:0.1.0",
            "ports" : [
              {
                "containerPort" : 10000,
                "name" : "akka-remote"
              },
              {
                "containerPort" : 10001,
                "name" : "akka-mgmt-http"
              },
              {
                "containerPort" : 10002,
                "name" : "http"
              }
            ],
            "imagePullPolicy" : "IfNotPresent",
            "volumeMounts" : [],
            "env" : [
              {
                "name" : "RP_APP_NAME",
                "value" : "akka-cluster-tooling-example"
              },
              {
                "name" : "RP_APP_TYPE",
                "value" : "basic"
              },
              {
                "name" : "RP_APP_VERSION",
                "value" : "0.1.0"
              },
              {
                "name" : "RP_ENDPOINTS",
                "value" : "AKKA_REMOTE,AKKA_MGMT_HTTP,HTTP"
              },
              {
                "name" : "RP_ENDPOINTS_COUNT",
                "value" : "3"
              },
              {
                "name" : "RP_ENDPOINT_0_BIND_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_0_BIND_PORT",
                "value" : "10000"
              },
              {
                "name" : "RP_ENDPOINT_0_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_0_PORT",
                "value" : "10000"
              },
              {
                "name" : "RP_ENDPOINT_1_BIND_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_1_BIND_PORT",
                "value" : "10001"
              },
              {
                "name" : "RP_ENDPOINT_1_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_1_PORT",
                "value" : "10001"
              },
              {
                "name" : "RP_ENDPOINT_2_BIND_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_2_BIND_PORT",
                "value" : "10002"
              },
              {
                "name" : "RP_ENDPOINT_2_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_2_PORT",
                "value" : "10002"
              },
              {
                "name" : "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT",
                "value" : "10001"
              },
              {
                "name" : "RP_ENDPOINT_AKKA_MGMT_HTTP_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_AKKA_MGMT_HTTP_PORT",
                "value" : "10001"
              },
              {
                "name" : "RP_ENDPOINT_AKKA_REMOTE_BIND_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_AKKA_REMOTE_BIND_PORT",
                "value" : "10000"
              },
              {
                "name" : "RP_ENDPOINT_AKKA_REMOTE_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_AKKA_REMOTE_PORT",
                "value" : "10000"
              },
              {
                "name" : "RP_ENDPOINT_HTTP_BIND_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_HTTP_BIND_PORT",
                "value" : "10002"
              },
              {
                "name" : "RP_ENDPOINT_HTTP_HOST",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_ENDPOINT_HTTP_PORT",
                "value" : "10002"
              },
              {
                "name" : "RP_JAVA_OPTS",
                "value" : "-Dconfig.resource=rp-application.conf -Dakka.cluster.bootstrap.contact-point-discovery.discovery-method=akka.discovery.reactive-lib-kubernetes -Dakka.cluster.bootstrap.contact-point-discovery.effective-name=akka-cluster-tooling-example -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=2 -Drp.akka-cluster-bootstrap.pod-label-selector=actorSystemName=my-system"
              },
              {
                "name" : "RP_KUBERNETES_POD_IP",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "status.podIP"
                  }
                }
              },
              {
                "name" : "RP_KUBERNETES_POD_NAME",
                "valueFrom" : {
                  "fieldRef" : {
                    "fieldPath" : "metadata.name"
                  }
                }
              },
              {
                "name" : "RP_MODULES",
                "value" : "akka-cluster-bootstrapping,common,service-discovery"
              },
              {
                "name" : "RP_PLATFORM",
                "value" : "kubernetes"
              }
            ]
          }
        ],
        "volumes" : []
      }
    }
  }
}
```