### PR TITLE
Check sbt reactive app version label if it exists

### DIFF
--- a/cli/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -42,15 +42,14 @@ object Main extends LazyLogging {
     val minor: Int = 4
     val minimum = s"$major.$minor.0"
 
-    private def parseVersion(version: String): Option[(Int, Int, Int)] = {
+    def parseVersion(version: String): Option[(Int, Int, Int)] = {
       // Only strings like "1.2.3" are supported, what comes after
       // doesn't matter so snapshots like "0.1.2-SNAPSHOT" are okay.
       try {
-        val parts = version.split("\\.")
+        val parts = version.split("-|\\.")
         Some(parts(0).toInt, parts(1).toInt, parts(2).toInt)
-      }
-      catch {
-        case e : Exception => None
+      } catch {
+        case _: Exception => None
       }
     }
 
@@ -66,7 +65,6 @@ object Main extends LazyLogging {
       }
     }
   }
-
 
   private def credentialsFile: Option[Path] =
     for {
@@ -153,6 +151,7 @@ object Main extends LazyLogging {
                 }
 
                 Try(getDockerHostConfig(imageName).get)
+                  .orElse(getDockerRegistryConfig(imageName))
                   .flatMap(validateConfig)
               }
 

--- a/cli/src/test/scala/MinVersionTest.scala
+++ b/cli/src/test/scala/MinVersionTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli
+
+import utest._
+
+object MinVersionTest extends TestSuite {
+  val tests = this{
+    "Parse version" - {
+      assert(Main.MinSupportedSbtReactiveApp.parseVersion("0.1.2") == Some((0, 1, 2)))
+      assert(Main.MinSupportedSbtReactiveApp.parseVersion("1.0.0-SNAPSHOT") == Some((1, 0, 0)))
+      assert(Main.MinSupportedSbtReactiveApp.parseVersion("2.4.8.0") == Some((2, 4, 8)))
+      assert(Main.MinSupportedSbtReactiveApp.parseVersion("1.0") == None)
+      assert(Main.MinSupportedSbtReactiveApp.parseVersion("0.x.1") == None)
+      assert(Main.MinSupportedSbtReactiveApp.parseVersion("blah") == None)
+    }
+  }
+}


### PR DESCRIPTION
For https://github.com/lightbend/sbt-reactive-app/issues/65 & https://github.com/lightbend/reactive-cli/issues/87

If no version label is found, it proceeds as usual. If version label is found, it is checked against the minimum supported version which is 0.4.0 for now.