### PR TITLE
Implement `--join-existing-akka-cluster` flag

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -93,7 +93,7 @@ object Main extends LazyLogging {
                 System.out.println(s"jq support: ${if (jqAvail) "Available" else "Unavailable"}")
               }
 
-            case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, _, _, Some(kubernetesArgs: KubernetesArgs), _, _, _, _, _) =>
+            case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, _, _, _, Some(kubernetesArgs: KubernetesArgs), _, _, _, _, _) =>
               implicit val httpSettings: HttpSettings =
                 inputArgs.tlsCacertsPath.fold(HttpSettings.default)(v => HttpSettings.default.copy(tlsCacertsPath = Some(v)))
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -70,6 +70,7 @@ case class GenerateDeploymentArgs(
   cpu: Option[Double] = None,
   memory: Option[Long] = None,
   diskSpace: Option[Long] = None,
+  joinExistingAkkaCluster: Boolean = false,
   targetRuntimeArgs: Option[TargetRuntimeArgs] = None,
   registryUsername: Option[String] = None,
   registryPassword: Option[String] = None,

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -166,6 +166,10 @@ object InputArgs {
             .text("Appends the expression specified to the paths of the generated Ingress resources")
             .action(IngressArgs.set((v, c) => c.copy(pathAppend = Some(v)))),
 
+          opt[Unit]("join-existing-akka-cluster")
+            .text("When provided, the pod controller will only join an already formed Akka Cluster")
+            .action(GenerateDeploymentArgs.set((_, args) => args.copy(joinExistingAkkaCluster = true))),
+
           opt[String]("namespace")
             .text("Resources will be generated with the supplied namespace")
             .action(KubernetesArgs.set((v, args) => args.copy(namespace = Some(v)))),
@@ -185,7 +189,7 @@ object InputArgs {
             .action(PodControllerArgs.set((v, args) => args.copy(imagePullPolicy = v))),
 
           opt[Int]("pod-controller-replicas")
-            .text("Sets the number of replicas for the Pod Controller resources")
+            .text("Sets the number of replicas for the Pod Controller resources. If Akka Cluster Bootstrap is enabled, this must be set to 2 or greater unless `--join-existing-akka-cluster` is provided")
             .validate(v => if (v >= 0) success else failure("Number of replicas must be zero or more"))
             .action(PodControllerArgs.set((v, args) => args.copy(numberOfReplicas = v))),
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -82,7 +82,8 @@ package object kubernetes extends LazyLogging {
         kubernetesArgs.podControllerArgs.numberOfReplicas,
         generateDeploymentArgs.externalServices,
         generateDeploymentArgs.deploymentType,
-        kubernetesArgs.transformPodControllers)
+        kubernetesArgs.transformPodControllers,
+        generateDeploymentArgs.joinExistingAkkaCluster)
       val services = Service.generate(
         annotations,
         serviceApiVersion,
@@ -97,8 +98,8 @@ package object kubernetes extends LazyLogging {
         kubernetesArgs.transformIngress)
 
       val validateAkkaCluster =
-        if (annotations.modules.contains(Module.AkkaClusterBootstrapping) && kubernetesArgs.podControllerArgs.numberOfReplicas < AkkaClusterMinimumReplicas)
-          s"Akka Cluster Bootstrapping is enabled so you must specify `--pod-controller-replicas 2` (or greater)".failureNel
+        if (annotations.modules.contains(Module.AkkaClusterBootstrapping) && kubernetesArgs.podControllerArgs.numberOfReplicas < AkkaClusterMinimumReplicas && !generateDeploymentArgs.joinExistingAkkaCluster)
+          s"Akka Cluster Bootstrapping is enabled so you must specify `--pod-controller-replicas 2` (or greater), or provide `--join-existing-akka-cluster` to only join already formed clusters".failureNel
         else
           ().successNel[String]
 

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -80,7 +80,8 @@ object InputArgsTest extends TestSuite {
                     "--generate-namespaces",
                     "--generate-pod-controllers",
                     "--generate-services",
-                    "--deployment-type", "rolling"),
+                    "--deployment-type", "rolling",
+                    "--join-existing-akka-cluster"),
                   InputArgs.default)
                 .get
 
@@ -102,6 +103,7 @@ object InputArgsTest extends TestSuite {
                 assert(!commandArgs.registryUseHttps)
                 assert(!commandArgs.registryValidateTls)
                 assert(commandArgs.externalServices == Map("cas1" -> Seq("1.2.3.4", "5.6.7.8"), "cas2" -> Seq("hello")))
+                assert(commandArgs.joinExistingAkkaCluster)
 
                 assert(targetRuntimeArgs.generateIngress)
                 assert(targetRuntimeArgs.generateNamespaces)

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -59,7 +59,7 @@ object DeploymentJsonTest extends TestSuite {
         "deploymentType" - {
           "Canary" - {
             Deployment
-              .generate(annotations, "apps/v1beta2", imageName, Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, CanaryDeploymentType, None)
+              .generate(annotations, "apps/v1beta2", imageName, Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, CanaryDeploymentType, None, false)
               .toOption
               .get
               .payload
@@ -72,7 +72,7 @@ object DeploymentJsonTest extends TestSuite {
 
           "BlueGreen" - {
             Deployment
-              .generate(annotations, "v1", imageName, Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, BlueGreenDeploymentType, None)
+              .generate(annotations, "v1", imageName, Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, BlueGreenDeploymentType, None, false)
               .toOption
               .get
               .payload
@@ -85,7 +85,7 @@ object DeploymentJsonTest extends TestSuite {
 
           "Rolling" - {
             Deployment
-              .generate(annotations, "v1", imageName, Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, RollingDeploymentType, None)
+              .generate(annotations, "v1", imageName, Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, RollingDeploymentType, None, false)
               .toOption
               .get
               .payload
@@ -349,7 +349,7 @@ object DeploymentJsonTest extends TestSuite {
             """.stripMargin.parse.right.get
 
           val result = Deployment.generate(annotations, "apps/v1beta2", imageName,
-            Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, CanaryDeploymentType, None).toOption.get
+            Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, CanaryDeploymentType, None, false).toOption.get
 
           // @TODO uncomment this test when we actually have the right format generated
           // @TODO i am proposing keeping them updated for now is counter-productive
@@ -359,12 +359,12 @@ object DeploymentJsonTest extends TestSuite {
         "should fail if application name is not defined" - {
           val invalid = annotations.copy(appName = None)
           assert(Deployment.generate(invalid, "apps/v1beta2", imageName,
-            Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None).toOption.isEmpty)
+            Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false).toOption.isEmpty)
         }
 
         "jq" - {
           Deployment
-            .generate(annotations, "apps/v1beta2", imageName, Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, Some(".jqTest = \"test\""))
+            .generate(annotations, "apps/v1beta2", imageName, Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, Some(".jqTest = \"test\""), false)
             .toOption
             .get
             .payload
@@ -388,7 +388,7 @@ object DeploymentJsonTest extends TestSuite {
 
           val generatedJson =
             Deployment
-              .generate(annotations, "apps/v1beta2", imageName, Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None)
+              .generate(annotations, "apps/v1beta2", imageName, Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false)
               .toOption
               .get
               .payload


### PR DESCRIPTION
This adds `--join-existing-akka-cluster` that when provided, ensures that 1) there is no minimum requirement for number of replicas, and 2) configures Akka Management to only join existing clusters (i.e. don't form a new one).

Complements the feature here: https://github.com/akka/akka-management/pull/96

This will be effective a noop until a new release of reactive-lib is done upgrading the version of Akka Management it uses (or if the user explicitly does so in his or her build).