### PR TITLE
Security improvements - auth header parsing & URI encoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,13 +23,13 @@ lazy val Names = new {
 
 lazy val Versions = new {
   val argonaut  = "6.2.1"
+  val fastparse = "1.0.0"
   val nodejs    = "0.4.2"
   val scala     = "2.11.12"
   val scalaz    = "7.2.16"
   val scopt     = "3.7.0"
   val slogging  = "0.6.0"
   val utest     = "0.5.3"
-  val fastparse = "1.0.0"
 }
 
 lazy val Platform = new {

--- a/build.sbt
+++ b/build.sbt
@@ -22,13 +22,14 @@ lazy val Names = new {
 }
 
 lazy val Versions = new {
-  val argonaut = "6.2.1"
-  val nodejs   = "0.4.2"
-  val scala    = "2.11.12"
-  val scalaz   = "7.2.16"
-  val scopt    = "3.7.0"
-  val slogging = "0.6.0"
-  val utest    = "0.5.3"
+  val argonaut  = "6.2.1"
+  val nodejs    = "0.4.2"
+  val scala     = "2.11.12"
+  val scalaz    = "7.2.16"
+  val scopt     = "3.7.0"
+  val slogging  = "0.6.0"
+  val utest     = "0.5.3"
+  val fastparse = "1.0.0"
 }
 
 lazy val Platform = new {
@@ -208,7 +209,8 @@ lazy val cli = crossProject(JSPlatform, NativePlatform)
       "com.github.scopt"  %%% "scopt"       % Versions.scopt,
       "io.argonaut"       %%% "argonaut"    % Versions.argonaut,
       "biz.enef"          %%% "slogging"    % Versions.slogging,
-      "org.scalaz"        %%% "scalaz-core" % Versions.scalaz
+      "org.scalaz"        %%% "scalaz-core" % Versions.scalaz,
+      "com.lihaoyi"       %%% "fastparse"   % Versions.fastparse
     )
   ))
   .settings(

--- a/cli/js/src/main/scala/com/lightbend/rp/reactivecli/Platform.scala
+++ b/cli/js/src/main/scala/com/lightbend/rp/reactivecli/Platform.scala
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets
 import scala.collection.mutable
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scalajs.js
+import scalajs.js.URIUtils
 import slogging._
 
 import js.JSConverters._
@@ -110,6 +111,8 @@ object Platform extends LazyLogging {
 
     promise.future
   }
+
+  def encodeURI(uri: String): String = URIUtils.encodeURI(uri)
 
   def mkDirs(path: String): Unit =
     Fs.mkdirSync(path)

--- a/cli/native/src/main/scala/com/lightbend/rp/reactivecli/Platform.scala
+++ b/cli/native/src/main/scala/com/lightbend/rp/reactivecli/Platform.scala
@@ -71,7 +71,7 @@ object Platform extends LazyLogging {
       case Success(r) => Future.successful(r)
     }
 
-  def encodeURI(uri: String) : String = {
+  def encodeURI(uri: String): String = {
     val enc = new URI(uri)
     enc.toASCIIString
   }

--- a/cli/native/src/main/scala/com/lightbend/rp/reactivecli/Platform.scala
+++ b/cli/native/src/main/scala/com/lightbend/rp/reactivecli/Platform.scala
@@ -18,6 +18,7 @@ package com.lightbend.rp.reactivecli
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{ Files, Paths }
+import java.net.URI
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
@@ -69,6 +70,11 @@ object Platform extends LazyLogging {
       case Failure(t) => Future.failed(t)
       case Success(r) => Future.successful(r)
     }
+
+  def encodeURI(uri: String) : String = {
+    val enc = new URI(uri)
+    enc.toASCIIString
+  }
 
   def mkDirs(path: String): Unit =
     Files.createDirectories(Paths.get(path))

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerEngine.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerEngine.scala
@@ -20,7 +20,6 @@ import argonaut._
 import com.lightbend.rp.reactivecli.concurrent._
 import com.lightbend.rp.reactivecli.files._
 import com.lightbend.rp.reactivecli.http._
-import com.lightbend.rp.reactivecli.Platform
 import scala.concurrent.{ ExecutionContext, Future }
 import slogging._
 
@@ -54,7 +53,7 @@ object DockerEngine extends LazyLogging {
       case Some(host) if host.startsWith("tcp://") =>
         val verify = env.get("DOCKER_TLS_VERIFY").contains("1")
         val protocol = if (verify) "https" else "http"
-        val url = Platform.encodeURI(s"$protocol://${host.replaceFirst("tcp://", "")}/images/$uri/json")
+        val url = encodeURI(s"$protocol://${host.replaceFirst("tcp://", "")}/images/$uri/json")
 
         logger.debug("Attempting to pull config from Engine, {}", url)
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerEngine.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerEngine.scala
@@ -20,6 +20,7 @@ import argonaut._
 import com.lightbend.rp.reactivecli.concurrent._
 import com.lightbend.rp.reactivecli.files._
 import com.lightbend.rp.reactivecli.http._
+import com.lightbend.rp.reactivecli.Platform
 import scala.concurrent.{ ExecutionContext, Future }
 import slogging._
 
@@ -53,7 +54,7 @@ object DockerEngine extends LazyLogging {
       case Some(host) if host.startsWith("tcp://") =>
         val verify = env.get("DOCKER_TLS_VERIFY").contains("1")
         val protocol = if (verify) "https" else "http"
-        val url = s"$protocol://${host.replaceFirst("tcp://", "")}/images/$uri/json"
+        val url = Platform.encodeURI(s"$protocol://${host.replaceFirst("tcp://", "")}/images/$uri/json")
 
         logger.debug("Attempting to pull config from Engine, {}", url)
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/http.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/http.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli
+
+import fastparse.all._
+
+package object http {
+  def encodeURI(uri: String): String = Platform.encodeURI(uri)
+
+  def parseAuthHeader(auth: String): Option[Map[String, String]] = {
+    val ws = P(CharIn(" \t").rep(1))
+    val letters = P(CharIn('a' to 'z', 'A' to 'Z') ~ CharsWhile(_ != '=', min = 0))
+    val value = P("\"" ~ CharsWhile(_ != '\"', min = 0).! ~ "\"")
+    val keyval = P(ws.? ~ letters.! ~ "=" ~ ws.? ~ value)
+    val parser = P(Start ~ keyval.rep(sep = ",") ~ End)
+
+    parser.parse(auth) match {
+      case Parsed.Success(seq, _) => Some(seq.toMap)
+      case Parsed.Failure(_, _, _) => None
+    }
+  }
+}

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
@@ -139,23 +139,5 @@ object DockerRegistryTest extends TestSuite {
       assert(DockerRegistry.parseImageUri(":").isFailure)
     }
 
-    "parseAuthHeader" - {
-      assert(DockerRegistry.parseAuthHeader("") == Some(Map()))
-      assert(DockerRegistry.parseAuthHeader("key=\"val1\"") == Some(Map("key" -> "val1")))
-      assert(DockerRegistry.parseAuthHeader("a=\"val1\",b = \"val2\"") == Some(Map("a" -> "val1", "b " -> "val2")))
-      assert(DockerRegistry.parseAuthHeader(" a=\"\",b = \"val2\"") == Some(Map("a" -> "", "b " -> "val2")))
-      assert(DockerRegistry.parseAuthHeader(" p  a=\"1\",b= \"2\"") == Some(Map("p  a" -> "1", "b" -> "2")))
-
-      val data = """Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:dockercloud/hello-world:pull""""
-      assert(DockerRegistry.parseAuthHeader(data) == Some(Map(
-        "Bearer realm" -> "https://auth.docker.io/token",
-        "service" -> "registry.docker.io",
-        "scope" -> "repository:dockercloud/hello-world:pull")))
-
-      assert(DockerRegistry.parseAuthHeader("key =") == None)
-      assert(DockerRegistry.parseAuthHeader("key = value") == None)
-      assert(DockerRegistry.parseAuthHeader(",") == None)
-      assert(DockerRegistry.parseAuthHeader("a=\"val1\"b = \"val2\"") == None)
-    }
   }
 }


### PR DESCRIPTION
For https://github.com/lightbend/reactive-cli/issues/12

This introduces a more robust auth header parser and encodes constructed request urls.

There are a few other places in the code which do split() based parsing, I left them as-is for now. I think split() is easier to read and faster for simple cases.