### PR TITLE
Rename generate-kubernetes-deployment -> generate-kubernetes-resources

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -74,7 +74,7 @@ object InputArgs {
         .text("Outputs the program's version")
         .action((_, inputArgs) => inputArgs.copy(commandArgs = Some(VersionArgs)))
 
-      cmd("generate-kubernetes-deployment")
+      cmd("generate-kubernetes-resources")
         .text("Generate Kubernetes resource files for kubectl")
         .action((_, inputArgs) => inputArgs.copy(commandArgs = Some(GenerateDeploymentArgs(targetRuntimeArgs = Some(KubernetesArgs())))))
         .children(

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -37,7 +37,7 @@ object InputArgsTest extends TestSuite {
           "minimum arguments" - {
             val result = parser.parse(
               Seq(
-                "generate-kubernetes-deployment",
+                "generate-kubernetes-resources",
                 "dockercloud/hello-world:1.0.0-SNAPSHOT"),
               InputArgs.default)
             assert(
@@ -53,7 +53,7 @@ object InputArgsTest extends TestSuite {
               val res = parser
                 .parse(
                   Seq(
-                    "generate-kubernetes-deployment",
+                    "generate-kubernetes-resources",
                     "--loglevel", "debug",
                     "--cainfo", mockCacerts,
                     "dockercloud/hello-world:1.0.0-SNAPSHOT",
@@ -124,7 +124,7 @@ object InputArgsTest extends TestSuite {
 
           "registry credentials" - {
             val baseArgs = Seq(
-              "generate-kubernetes-deployment",
+              "generate-kubernetes-resources",
               "dockercloud/hello-world:1.0.0-SNAPSHOT")
 
             "should fail if username is defined but password is empty" - {


### PR DESCRIPTION
Toward having multiple Pod Controller / Workload types, this renames `generate-kubernetes-deployment` to `generate-kubernetes-resources`.