### PR TITLE
Name override, applications, jobs

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -93,7 +93,7 @@ object Main extends LazyLogging {
                 System.out.println(s"jq support: ${if (jqAvail) "Available" else "Unavailable"}")
               }
 
-            case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, _, _, _, Some(kubernetesArgs: KubernetesArgs), _, _, _, _, _) =>
+            case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, _, _, _, _, _, Some(kubernetesArgs: KubernetesArgs), _, _, _, _, _) =>
               implicit val httpSettings: HttpSettings =
                 inputArgs.tlsCacertsPath.fold(HttpSettings.default)(v => HttpSettings.default.copy(tlsCacertsPath = Some(v)))
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -63,8 +63,10 @@ case object RollingDeploymentType extends DeploymentType
  * Represents the input argument for `generate-deployment` command.
  */
 case class GenerateDeploymentArgs(
+  application: Option[String] = None,
   deploymentType: DeploymentType = CanaryDeploymentType,
   dockerImage: Option[String] = None,
+  name: Option[String] = None,
   version: Option[String] = None,
   environmentVariables: Map[String, String] = Map.empty,
   cpu: Option[Double] = None,

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -83,6 +83,11 @@ object InputArgs {
             .required()
             .action(GenerateDeploymentArgs.set((v, args) => args.copy(dockerImage = Some(v)))),
 
+          opt[String]("application") /* note: this argument will apply for other targets */
+            .text("Application to generate resources for. If omitted, resources are generated for the default application. If generating for an alternate application, its name will be part of the generated resource names")
+            .optional()
+            .action(GenerateDeploymentArgs.set((v, args) => args.copy(application = Some(v)))),
+
           opt[DeploymentType]("deployment-type")
             .text(s"Sets the deployment type. Default: ${DeploymentType.Canary}; Available: ${DeploymentType.All.mkString(", ")}")
             .optional()
@@ -169,6 +174,11 @@ object InputArgs {
           opt[Unit]("join-existing-akka-cluster")
             .text("When provided, the pod controller will only join an already formed Akka Cluster")
             .action(GenerateDeploymentArgs.set((_, args) => args.copy(joinExistingAkkaCluster = true))),
+
+          opt[String]("name")
+            .text("Uses specified name for generated resources instead of name in the Docker image")
+            .optional()
+            .action(GenerateDeploymentArgs.set((v, args) => args.copy(name = Some(v)))),
 
           opt[String]("namespace")
             .text("Resources will be generated with the supplied namespace")

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/KubernetesArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/KubernetesArgs.scala
@@ -18,7 +18,7 @@ package com.lightbend.rp.reactivecli.argparse.kubernetes
 
 import com.lightbend.rp.reactivecli.argparse.{ GenerateDeploymentArgs, InputArgs, TargetRuntimeArgs }
 import com.lightbend.rp.reactivecli.process.kubectl
-import com.lightbend.rp.reactivecli.runtime.kubernetes.Deployment
+import com.lightbend.rp.reactivecli.runtime.kubernetes.PodTemplate
 import java.io.PrintStream
 import scala.concurrent.Future
 
@@ -42,11 +42,12 @@ object KubernetesArgs {
   sealed trait Output
 
   val DefaultNumberOfReplicas: Int = 1
-  val DefaultImagePullPolicy: Deployment.ImagePullPolicy.Value = Deployment.ImagePullPolicy.IfNotPresent
+  val DefaultImagePullPolicy: PodTemplate.ImagePullPolicy.Value = PodTemplate.ImagePullPolicy.IfNotPresent
 
+  lazy val DefaultAppsApiVersion: Future[String] = kubectl.findApi("apps/v1beta2", "apps/v1beta1")
+  lazy val DefaultBatchApiVersion: Future[String] = kubectl.findApi("batch/v1", "batch/v1beta1")
   lazy val DefaultNamespaceApiVersion: Future[String] = kubectl.findApi("v1")
   lazy val DefaultIngressApiVersion: Future[String] = kubectl.findApi("extensions/v1beta1")
-  lazy val DefaultPodControllerApiVersion: Future[String] = kubectl.findApi("apps/v1beta2", "apps/v1beta1")
   lazy val DefaultServiceApiVersion: Future[String] = kubectl.findApi("v1")
 
   /**

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/PodControllerArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/PodControllerArgs.scala
@@ -17,10 +17,28 @@
 package com.lightbend.rp.reactivecli.argparse.kubernetes
 
 import com.lightbend.rp.reactivecli.argparse.InputArgs
-import com.lightbend.rp.reactivecli.runtime.kubernetes.Deployment
+import com.lightbend.rp.reactivecli.runtime.kubernetes.PodTemplate
+import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
 object PodControllerArgs {
+  sealed trait ControllerType {
+    def arg: String
+  }
+
+  object ControllerType {
+    case object Deployment extends ControllerType {
+      val arg: String = "deployment"
+    }
+
+    case object Job extends ControllerType {
+      val arg: String = "job"
+    }
+
+    val All: Seq[ControllerType] = Seq(Deployment, Job)
+    val Default: ControllerType = Deployment
+  }
+
   /**
    * Convenience method to set the [[PodControllerArgs]] values when parsing the complete user input.
    * Refer to [[InputArgs.parser()]] for more details.
@@ -39,6 +57,8 @@ object PodControllerArgs {
  * Represents user input arguments required to build Kubernetes Deployment resource.
  */
 case class PodControllerArgs(
-  apiVersion: Future[String] = KubernetesArgs.DefaultPodControllerApiVersion,
+  appsApiVersion: Future[String] = KubernetesArgs.DefaultAppsApiVersion,
+  batchApiVersion: Future[String] = KubernetesArgs.DefaultBatchApiVersion,
+  controllerType: PodControllerArgs.ControllerType = PodControllerArgs.ControllerType.Deployment,
   numberOfReplicas: Int = KubernetesArgs.DefaultNumberOfReplicas,
-  imagePullPolicy: Deployment.ImagePullPolicy.Value = KubernetesArgs.DefaultImagePullPolicy)
+  imagePullPolicy: PodTemplate.ImagePullPolicy.Value = KubernetesArgs.DefaultImagePullPolicy)

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.runtime.kubernetes
+
+import argonaut._
+import com.lightbend.rp.reactivecli.annotations.kubernetes.{ ConfigMapEnvironmentVariable, FieldRefEnvironmentVariable, SecretKeyRefEnvironmentVariable }
+import com.lightbend.rp.reactivecli.annotations._
+import com.lightbend.rp.reactivecli.argparse._
+import scala.collection.immutable.Seq
+import scalaz._
+
+import Argonaut._
+import Scalaz._
+
+object PodTemplate {
+
+  object RpEnvironmentVariables {
+    /**
+     * Environment variables in this set will be space-concatenated when the various environment variable
+     * maps are merged.
+     */
+    private val ConcatLiteralEnvs = Set("RP_JAVA_OPTS")
+
+    /**
+     * Creates pod related environment variables using the Kubernetes Downward API:
+     *
+     * https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables
+     */
+    private val PodEnvs = Map(
+      "RP_PLATFORM" -> LiteralEnvironmentVariable("kubernetes"),
+      "RP_KUBERNETES_POD_NAME" -> FieldRefEnvironmentVariable("metadata.name"),
+      "RP_KUBERNETES_POD_IP" -> FieldRefEnvironmentVariable("status.podIP"))
+
+    /**
+     * Generates pod environment variables specific for RP applications.
+     */
+    def envs(annotations: Annotations, serviceResourceName: String, noOfReplicas: Int, externalServices: Map[String, Seq[String]], joinExistingAkkaCluster: Boolean): Map[String, EnvironmentVariable] =
+      mergeEnvs(
+        PodEnvs,
+        namespaceEnv(annotations.namespace),
+        appNameEnvs(annotations.appName),
+        annotations.version.fold(Map.empty[String, EnvironmentVariable])(versionEnvs),
+        appTypeEnvs(annotations.appType, annotations.modules),
+        configEnvs(annotations.configResource),
+        endpointEnvs(annotations.endpoints),
+        akkaClusterEnvs(annotations.modules, annotations.namespace, serviceResourceName, noOfReplicas, annotations.akkaClusterBootstrapSystemName, joinExistingAkkaCluster),
+        externalServicesEnvs(annotations.modules, externalServices))
+
+    private[kubernetes] def namespaceEnv(namespace: Option[String]): Map[String, EnvironmentVariable] =
+      namespace.fold(Map.empty[String, EnvironmentVariable])(v => Map("RP_NAMESPACE" -> LiteralEnvironmentVariable(v)))
+
+    private[kubernetes] def appNameEnvs(appName: Option[String]): Map[String, EnvironmentVariable] =
+      appName.fold(Map.empty[String, EnvironmentVariable])(v => Map("RP_APP_NAME" -> LiteralEnvironmentVariable(v)))
+
+    private[kubernetes] def appTypeEnvs(appType: Option[String], modules: Set[String]): Map[String, EnvironmentVariable] = {
+      appType
+        .toVector
+        .map("RP_APP_TYPE" -> LiteralEnvironmentVariable(_)) ++ (
+          if (modules.isEmpty) Seq.empty else Seq("RP_MODULES" -> LiteralEnvironmentVariable(modules.toVector.sorted.mkString(","))))
+    }.toMap
+
+    private[kubernetes] def akkaClusterEnvs(modules: Set[String], namespace: Option[String], serviceResourceName: String, noOfReplicas: Int, akkaClusterBootstrapSystemName: Option[String], joinExistingAkkaCluster: Boolean): Map[String, EnvironmentVariable] =
+      if (!modules.contains(Module.AkkaClusterBootstrapping))
+        Map.empty
+      else
+        Map(
+          "RP_JAVA_OPTS" -> LiteralEnvironmentVariable(
+            Seq(
+              s"-Dakka.discovery.method=kubernetes-api",
+              namespace.fold("")(ns => s"-Dakka.discovery.kubernetes-api.pod-namespace=$ns"),
+              s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName",
+              s"-Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas",
+              akkaClusterBootstrapSystemName.fold("-Dakka.discovery.kubernetes-api.pod-label-selector=appName=%s")(systemName => s"-Dakka.discovery.kubernetes-api.pod-label-selector=actorSystemName=$systemName"),
+              s"${if (joinExistingAkkaCluster) "-Dakka.management.cluster.bootstrap.form-new-cluster=false" else ""}")
+              .filter(_.nonEmpty)
+              .mkString(" ")))
+
+    private[kubernetes] def configEnvs(config: Option[String]): Map[String, EnvironmentVariable] =
+      config
+        .map(c => Map("RP_JAVA_OPTS" -> LiteralEnvironmentVariable(s"-Dconfig.resource=$c")))
+        .getOrElse(Map.empty)
+
+    private[kubernetes] def externalServicesEnvs(modules: Set[String], externalServices: Map[String, Seq[String]]): Map[String, EnvironmentVariable] =
+      if (!modules.contains(Module.ServiceDiscovery))
+        Map.empty
+      else
+        Map(
+          "RP_JAVA_OPTS" -> LiteralEnvironmentVariable(
+            externalServices
+              .flatMap {
+                case (name, addresses) =>
+                  // We allow '/' as that's the convention used: $serviceName/$endpoint
+                  // We allow '_' as it's currently used for Lagom defaults, i.e. "cas_native"
+
+                  val arguments =
+                    for {
+                      (address, i) <- addresses.zipWithIndex
+                    } yield s"-Dcom.lightbend.platform-tooling.service-discovery.external-service-addresses.${serviceName(name, Set('/', '_'))}.$i=$address"
+
+                  arguments
+              }
+              .mkString(" ")))
+
+    private[kubernetes] def versionEnvs(version: String): Map[String, EnvironmentVariable] =
+      Map(
+        "RP_APP_VERSION" -> LiteralEnvironmentVariable(version))
+
+    private[kubernetes] def endpointEnvs(endpoints: Map[String, Endpoint]): Map[String, EnvironmentVariable] =
+      if (endpoints.isEmpty)
+        Map(
+          "RP_ENDPOINTS_COUNT" -> LiteralEnvironmentVariable("0"))
+      else
+        Map(
+          "RP_ENDPOINTS_COUNT" -> LiteralEnvironmentVariable(endpoints.size.toString),
+          "RP_ENDPOINTS" -> LiteralEnvironmentVariable(
+            endpoints.values.toList
+              .sortBy(_.index)
+              .map(v => envVarName(v.name))
+              .mkString(","))) ++
+          endpointPortEnvs(endpoints)
+
+    private[kubernetes] def endpointPortEnvs(endpoints: Map[String, Endpoint]): Map[String, EnvironmentVariable] =
+      AssignedPort.assignPorts(endpoints)
+        .flatMap { assigned =>
+          val assignedPortEnv = LiteralEnvironmentVariable(assigned.port.toString)
+          val hostEnv = FieldRefEnvironmentVariable("status.podIP")
+          Seq(
+            s"RP_ENDPOINT_${envVarName(assigned.endpoint.name)}_HOST" -> hostEnv,
+            s"RP_ENDPOINT_${envVarName(assigned.endpoint.name)}_BIND_HOST" -> hostEnv,
+            s"RP_ENDPOINT_${envVarName(assigned.endpoint.name)}_PORT" -> assignedPortEnv,
+            s"RP_ENDPOINT_${envVarName(assigned.endpoint.name)}_BIND_PORT" -> assignedPortEnv,
+            s"RP_ENDPOINT_${assigned.endpoint.index}_HOST" -> hostEnv,
+            s"RP_ENDPOINT_${assigned.endpoint.index}_BIND_HOST" -> hostEnv,
+            s"RP_ENDPOINT_${assigned.endpoint.index}_PORT" -> assignedPortEnv,
+            s"RP_ENDPOINT_${assigned.endpoint.index}_BIND_PORT" -> assignedPortEnv)
+        }
+        .toMap
+
+    private[kubernetes] def mergeEnvs(envs: Map[String, EnvironmentVariable]*): Map[String, EnvironmentVariable] = {
+      envs.foldLeft(Map.empty[String, EnvironmentVariable]) {
+        case (a1, n) =>
+          n.foldLeft(a1) {
+            case (a2, (key, LiteralEnvironmentVariable(v))) if ConcatLiteralEnvs.contains(key) =>
+              a2.updated(key, a2.get(key) match {
+                case Some(LiteralEnvironmentVariable(ov)) => LiteralEnvironmentVariable(s"$ov $v".trim)
+                case _ => LiteralEnvironmentVariable(v)
+              })
+
+            case (a2, (key, value)) =>
+              a2.updated(key, value)
+          }
+      }
+    }
+  }
+
+  /**
+   * Represents possible values for imagePullPolicy field within the Kubernetes pod template.
+   */
+  object ImagePullPolicy extends Enumeration {
+    val Never, IfNotPresent, Always = Value
+  }
+
+  object RestartPolicy extends Enumeration {
+    val Never, OnFailure, Always = Value
+  }
+
+  case class ResourceLimits(cpu: Option[Double], memory: Option[Long])
+
+  private[kubernetes] val VersionSeparator = "-v"
+
+  implicit def imagePullPolicyEncode = EncodeJson[ImagePullPolicy.Value] {
+    case ImagePullPolicy.Never => "Never".asJson
+    case ImagePullPolicy.IfNotPresent => "IfNotPresent".asJson
+    case ImagePullPolicy.Always => "Always".asJson
+  }
+
+  implicit def restartPolicyEncode = EncodeJson[RestartPolicy.Value] {
+    case RestartPolicy.Never => jString("Never")
+    case RestartPolicy.OnFailure => jString("OnFailure")
+    case RestartPolicy.Always => jString("Always")
+  }
+
+  implicit def literalEnvironmentVariableEncode = EncodeJson[LiteralEnvironmentVariable] { env =>
+    Json("value" -> env.value.asJson)
+  }
+
+  implicit def fieldRefEnvironmentVariableEncode = EncodeJson[FieldRefEnvironmentVariable] { env =>
+    Json(
+      "valueFrom" -> Json(
+        "fieldRef" -> Json(
+          "fieldPath" -> env.fieldPath.asJson)))
+  }
+
+  implicit def secretKeyRefEnvironmentVariableEncode = EncodeJson[SecretKeyRefEnvironmentVariable] { env =>
+    Json(
+      "valueFrom" -> Json(
+        "secretKeyRef" -> Json(
+          "name" -> env.name.asJson,
+          "key" -> env.key.asJson)))
+  }
+
+  implicit def configMapEnvironmentVariableEncode = EncodeJson[ConfigMapEnvironmentVariable] { env =>
+    Json(
+      "valueFrom" -> Json(
+        "configMapKeyRef" -> Json(
+          "name" -> env.mapName.asJson,
+          "key" -> env.key.asJson)))
+  }
+
+  implicit def environmentVariableEncode = EncodeJson[EnvironmentVariable] {
+    case v: LiteralEnvironmentVariable => v.asJson
+    case v: FieldRefEnvironmentVariable => v.asJson
+    case v: ConfigMapEnvironmentVariable => v.asJson
+    case v: SecretKeyRefEnvironmentVariable => v.asJson
+  }
+
+  implicit def environmentVariablesEncode = EncodeJson[Map[String, EnvironmentVariable]] { envs =>
+    envs
+      .toList
+      .sortBy(_._1)
+      .map {
+        case (envName, env) =>
+          Json("name" -> envName.asJson).deepmerge(env.asJson)
+      }
+      .asJson
+  }
+
+  implicit def assignedEncode = EncodeJson[AssignedPort] { assigned =>
+    Json(
+      "containerPort" -> assigned.port.asJson,
+      "name" -> serviceName(assigned.endpoint.name).asJson)
+  }
+
+  implicit def endpointsEncode = EncodeJson[Map[String, Endpoint]] { endpoints =>
+    AssignedPort.assignPorts(endpoints)
+      .toList
+      .sortBy(_.endpoint.index)
+      .map(_.asJson)
+      .asJson
+  }
+
+  implicit def resourceLimitsEncode = EncodeJson[ResourceLimits] {
+    case ResourceLimits(cpu, memory) =>
+      val memoryJson = memory.map({ v => Json("memory" -> v.asJson) }).getOrElse(jEmptyObject)
+      val cpuJson = cpu.map({ v => Json("cpu" -> v.asJson) }).getOrElse(jEmptyObject)
+      if (cpu.isEmpty && memory.isEmpty) {
+        jEmptyObject
+      } else {
+        Json(
+          "resources" -> Json(
+            "limits" -> cpuJson.deepmerge(memoryJson),
+            "request" -> cpuJson.deepmerge(memoryJson)))
+      }
+  }
+
+  /**
+   * Builds [[PodTemplate]] resource.
+   */
+  def generate(
+    annotations: Annotations,
+    apiVersion: String,
+    application: Option[String],
+    imageName: String,
+    imagePullPolicy: ImagePullPolicy.Value,
+    noOfReplicas: Int,
+    restartPolicy: RestartPolicy.Value,
+    externalServices: Map[String, Seq[String]],
+    deploymentType: DeploymentType,
+    joinExistingAkkaCluster: Boolean,
+    applicationArgs: Option[Seq[String]],
+    appName: String,
+    appNameVersion: String,
+    labels: Map[String, String]): PodTemplate = {
+    val serviceResourceName =
+      deploymentType match {
+        case CanaryDeploymentType => appName
+        case BlueGreenDeploymentType => appNameVersion
+        case RollingDeploymentType => appName
+      }
+
+    val secretNames =
+      annotations
+        .secrets
+        .map(_.name)
+        .distinct
+        .map(ns => (ns, serviceName(ns), s"secret-${serviceName(ns)}"))
+        .toList
+
+    val resourceLimits = ResourceLimits(annotations.cpu, annotations.memory)
+
+    val enableChecks =
+      annotations.modules.contains(Module.Status) && annotations.modules.contains(Module.AkkaManagement)
+
+    val livenessProbe =
+      if (enableChecks)
+        Json("livenessProbe" ->
+          Json(
+            "httpGet" -> Json(
+              "path" -> jString("/platform-tooling/healthy"),
+              "port" -> jString(AkkaManagementPortName)),
+            "periodSeconds" -> jNumber(StatusPeriodSeconds)))
+      else
+        jEmptyObject
+
+    val readinessProbe =
+      if (enableChecks)
+        Json("readinessProbe" ->
+          Json(
+            "httpGet" -> Json(
+              "path" -> jString("/platform-tooling/ready"),
+              "port" -> jString(AkkaManagementPortName)),
+            "periodSeconds" -> jNumber(StatusPeriodSeconds)))
+      else
+        jEmptyObject
+
+    val commandArgs =
+      applicationArgs match {
+        case None =>
+          jEmptyObject
+
+        case Some(c) =>
+          if (c.isEmpty)
+            jEmptyObject
+          else
+            Json(
+              "command" -> jArrayElements(jString(c.head)),
+              "args" -> jArray(c.tail.map(jString).toList))
+      }
+
+    PodTemplate(
+      Json(
+        "metadata" -> Json("labels" -> labels.asJson),
+        "spec" -> Json(
+          "restartPolicy" -> restartPolicy.asJson,
+          "containers" -> jArrayElements(
+            Json(
+              "name" -> appName.asJson,
+              "image" -> imageName.asJson,
+              "imagePullPolicy" -> imagePullPolicy.asJson,
+              "env" -> RpEnvironmentVariables.mergeEnvs(
+                annotations.environmentVariables ++
+                  RpEnvironmentVariables.envs(annotations, serviceResourceName, noOfReplicas, externalServices, joinExistingAkkaCluster)).asJson,
+              "ports" -> annotations.endpoints.asJson,
+              "volumeMounts" -> secretNames
+                .map {
+                  case (_, secretServiceName, volumeName) =>
+                    Json(
+                      "mountPath" -> s"/rp/secrets/$secretServiceName".asJson,
+                      "name" -> jString(volumeName))
+                }
+                .asJson)
+              .deepmerge(commandArgs)
+              .deepmerge(readinessProbe)
+              .deepmerge(livenessProbe)
+              .deepmerge(resourceLimits.asJson)),
+          "volumes" -> secretNames
+            .map {
+              case (secretName, _, volumeName) =>
+                Json(
+                  "name" -> jString(volumeName),
+                  "secret" -> Json("secretName" -> jString(secretName)))
+            }.asJson)))
+  }
+}
+
+case class PodTemplate(json: Json)

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
@@ -62,7 +62,7 @@ object Service {
     (annotations.appNameValidation |@| annotations.versionValidation) { (rawAppName, version) =>
       // FIXME there's a bit of code duplicate in Deployment
       val appName = serviceName(rawAppName)
-      val appNameVersion = serviceName(s"$appName${Deployment.VersionSeparator}$version")
+      val appNameVersion = serviceName(s"$appName${PodTemplate.VersionSeparator}$version")
 
       val selector =
         deploymentType match {

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -77,6 +77,7 @@ package object kubernetes extends LazyLogging {
       val deployments = Deployment.generate(
         annotations,
         podControllerApiVersion,
+        generateDeploymentArgs.application,
         generateDeploymentArgs.dockerImage.get,
         kubernetesArgs.podControllerArgs.imagePullPolicy,
         kubernetesArgs.podControllerArgs.numberOfReplicas,

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
@@ -272,21 +272,21 @@ object AnnotationsTest extends TestSuite {
           Annotations(
             Map("com.lightbend.rp.name" -> "test1"),
             GenerateDeploymentArgs(name = Some("test2"))) == Annotations(
-            namespace = None,
-            applications = Vector.empty,
-            appName = Some("test2"),
-            appType = None,
-            configResource = None,
-            diskSpace = None,
-            memory = None,
-            cpu = None,
-            endpoints = Map.empty,
-            secrets = Seq.empty,
-            privileged = false,
-            environmentVariables = Map.empty,
-            version = None,
-            modules = Set.empty,
-            akkaClusterBootstrapSystemName = None))
+              namespace = None,
+              applications = Vector.empty,
+              appName = Some("test2"),
+              appType = None,
+              configResource = None,
+              diskSpace = None,
+              memory = None,
+              cpu = None,
+              endpoints = Map.empty,
+              secrets = Seq.empty,
+              privileged = false,
+              environmentVariables = Map.empty,
+              version = None,
+              modules = Set.empty,
+              akkaClusterBootstrapSystemName = None))
       }
 
       "version (argument override)" - {

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
@@ -112,6 +112,7 @@ object AnnotationsTest extends TestSuite {
       assert(
         Annotations(Map.empty, GenerateDeploymentArgs()) == Annotations(
           namespace = None,
+          applications = Vector.empty,
           appName = None,
           appType = None,
           configResource = None,
@@ -136,6 +137,12 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.app-name" -> "my-app",
               "com.lightbend.rp.app-type" -> "basic",
               "com.lightbend.rp.app-version" -> "3.2.1-SNAPSHOT",
+              "com.lightbend.rp.applications.0.name" -> "test",
+              "com.lightbend.rp.applications.0.arguments.0" -> "arg0",
+              "com.lightbend.rp.applications.0.arguments.1" -> "arg1",
+              "com.lightbend.rp.applications.1.name" -> "test2",
+              "com.lightbend.rp.applications.1.arguments.0" -> "arrrg0",
+              "com.lightbend.rp.applications.1.arguments.1" -> "arrrg1",
               "com.lightbend.rp.config-resource" -> "my-app.conf",
               "com.lightbend.rp.disk-space" -> "65536",
               "com.lightbend.rp.memory" -> "8192",
@@ -174,6 +181,9 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.akka-cluster-bootstrap.system-name" -> "test"),
             GenerateDeploymentArgs()) == Annotations(
               namespace = None,
+              applications = Vector(
+                "test" -> Vector("arg0", "arg1"),
+                "test2" -> Vector("arrrg0", "arrrg1")),
               appName = Some("my-app"),
               appType = Some("basic"),
               configResource = Some("my-app.conf"),
@@ -215,6 +225,7 @@ object AnnotationsTest extends TestSuite {
               targetRuntimeArgs = Some(KubernetesArgs(
                 namespace = Some("chirper"))))) == Annotations(
               namespace = Some("chirper"),
+              applications = Vector.empty,
               appName = None,
               appType = None,
               configResource = None,
@@ -240,6 +251,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.app-version" -> "3.2.1"),
             GenerateDeploymentArgs()) == Annotations(
               namespace = None,
+              applications = Vector.empty,
               appName = None,
               appType = None,
               configResource = None,
@@ -255,12 +267,35 @@ object AnnotationsTest extends TestSuite {
               akkaClusterBootstrapSystemName = None))
       }
 
+      "name (argument override)" - {
+        assert(
+          Annotations(
+            Map("com.lightbend.rp.name" -> "test1"),
+            GenerateDeploymentArgs(name = Some("test2"))) == Annotations(
+            namespace = None,
+            applications = Vector.empty,
+            appName = Some("test2"),
+            appType = None,
+            configResource = None,
+            diskSpace = None,
+            memory = None,
+            cpu = None,
+            endpoints = Map.empty,
+            secrets = Seq.empty,
+            privileged = false,
+            environmentVariables = Map.empty,
+            version = None,
+            modules = Set.empty,
+            akkaClusterBootstrapSystemName = None))
+      }
+
       "version (argument override)" - {
         assert(
           Annotations(
             Map("com.lightbend.rp.app-version" -> "3.2.1"),
             GenerateDeploymentArgs(version = Some("2.1.3"))) == Annotations(
               namespace = None,
+              applications = Vector.empty,
               appName = None,
               appType = None,
               configResource = None,
@@ -287,6 +322,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.endpoints.1.port" -> "1234"),
             GenerateDeploymentArgs()) == Annotations(
               namespace = None,
+              applications = Vector.empty,
               appName = None,
               appType = None,
               configResource = None,
@@ -312,6 +348,7 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.endpoints.1.port" -> "1234"),
             GenerateDeploymentArgs()) == Annotations(
               namespace = None,
+              applications = Vector.empty,
               appName = None,
               appType = None,
               configResource = None,

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -81,7 +81,8 @@ object InputArgsTest extends TestSuite {
                     "--generate-pod-controllers",
                     "--generate-services",
                     "--deployment-type", "rolling",
-                    "--join-existing-akka-cluster"),
+                    "--join-existing-akka-cluster",
+                    "--name", "test"),
                   InputArgs.default)
                 .get
 
@@ -95,6 +96,7 @@ object InputArgsTest extends TestSuite {
 
                 val targetRuntimeArgs = commandArgs.targetRuntimeArgs.get.asInstanceOf[KubernetesArgs]
 
+                assert(commandArgs.name == Some("test"))
                 assert(commandArgs.deploymentType == RollingDeploymentType)
                 assert(commandArgs.dockerImage == Some("dockercloud/hello-world:1.0.0-SNAPSHOT"))
                 assert(commandArgs.environmentVariables == Map("test1" -> "test2"))

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -58,7 +58,8 @@ object InputArgsTest extends TestSuite {
                     "--cainfo", mockCacerts,
                     "dockercloud/hello-world:1.0.0-SNAPSHOT",
                     "--namespace", "chirper",
-                    "--pod-controller-api-version", "hello1",
+                    "--apps-api-version", "hello1",
+                    "--batch-api-version", "hello2",
                     "--pod-controller-replicas", "10",
                     "--pod-controller-image-pull-policy", "Always",
                     "--service-cluster-ip", "10.0.0.1",
@@ -82,7 +83,8 @@ object InputArgsTest extends TestSuite {
                     "--generate-services",
                     "--deployment-type", "rolling",
                     "--join-existing-akka-cluster",
-                    "--name", "test"),
+                    "--name", "test",
+                    "--pod-controller-type", "job"),
                   InputArgs.default)
                 .get
 
@@ -113,13 +115,15 @@ object InputArgsTest extends TestSuite {
                 assert(targetRuntimeArgs.generateServices)
                 assert(targetRuntimeArgs.namespace == Some("chirper"))
                 assert(targetRuntimeArgs.output == KubernetesArgs.Output.SaveToFile("/tmp/foo"))
-                assert(targetRuntimeArgs.podControllerArgs.apiVersion.value.get.get == "hello1")
+                assert(targetRuntimeArgs.podControllerArgs.appsApiVersion.value.get.get == "hello1")
+                assert(targetRuntimeArgs.podControllerArgs.batchApiVersion.value.get.get == "hello2")
                 assert(targetRuntimeArgs.podControllerArgs.numberOfReplicas == 10)
                 assert(targetRuntimeArgs.serviceArgs.apiVersion.value.get.get == "hello3")
                 assert(targetRuntimeArgs.serviceArgs.clusterIp == Some("10.0.0.1"))
                 assert(targetRuntimeArgs.ingressArgs.apiVersion.value.get.get == "hello2")
                 assert(targetRuntimeArgs.ingressArgs.ingressAnnotations == Map("ing" -> "123"))
                 assert(targetRuntimeArgs.ingressArgs.pathAppend == Some(".*"))
+                assert(targetRuntimeArgs.podControllerArgs.controllerType == PodControllerArgs.ControllerType.Job)
               }
             }
           }

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -28,6 +28,7 @@ import Argonaut._
 
 object DeploymentJsonTest extends TestSuite {
   import Deployment._
+  import PodTemplate._
 
   val endpoints = Map(
     "ep1" -> HttpEndpoint(0, "ep1", 0, Seq(HttpIngress(Seq(80, 443), Seq.empty, Seq("^/.*")))),
@@ -60,7 +61,7 @@ object DeploymentJsonTest extends TestSuite {
         "deploymentType" - {
           "Canary" - {
             Deployment
-              .generate(annotations, "apps/v1beta2", None, imageName, Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, CanaryDeploymentType, None, false)
+              .generate(annotations, "apps/v1beta2", None, imageName, PodTemplate.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, CanaryDeploymentType, None, false)
               .toOption
               .get
               .payload
@@ -73,7 +74,7 @@ object DeploymentJsonTest extends TestSuite {
 
           "BlueGreen" - {
             Deployment
-              .generate(annotations, "v1", None, imageName, Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, BlueGreenDeploymentType, None, false)
+              .generate(annotations, "v1", None, imageName, PodTemplate.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, BlueGreenDeploymentType, None, false)
               .toOption
               .get
               .payload
@@ -86,7 +87,7 @@ object DeploymentJsonTest extends TestSuite {
 
           "Rolling" - {
             Deployment
-              .generate(annotations, "v1", None, imageName, Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, RollingDeploymentType, None, false)
+              .generate(annotations, "v1", None, imageName, PodTemplate.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, RollingDeploymentType, None, false)
               .toOption
               .get
               .payload
@@ -350,7 +351,7 @@ object DeploymentJsonTest extends TestSuite {
             """.stripMargin.parse.right.get
 
           val result = Deployment.generate(annotations, "apps/v1beta2", None, imageName,
-            Deployment.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, CanaryDeploymentType, None, false).toOption.get
+            PodTemplate.ImagePullPolicy.Never, noOfReplicas = 1, Map.empty, CanaryDeploymentType, None, false).toOption.get
 
           // @TODO uncomment this test when we actually have the right format generated
           // @TODO i am proposing keeping them updated for now is counter-productive
@@ -360,12 +361,12 @@ object DeploymentJsonTest extends TestSuite {
         "should fail if application name is not defined" - {
           val invalid = annotations.copy(appName = None)
           assert(Deployment.generate(invalid, "apps/v1beta2", None, imageName,
-            Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false).toOption.isEmpty)
+            PodTemplate.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false).toOption.isEmpty)
         }
 
         "jq" - {
           Deployment
-            .generate(annotations, "apps/v1beta2", None, imageName, Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, Some(".jqTest = \"test\""), false)
+            .generate(annotations, "apps/v1beta2", None, imageName, PodTemplate.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, Some(".jqTest = \"test\""), false)
             .toOption
             .get
             .payload
@@ -375,7 +376,7 @@ object DeploymentJsonTest extends TestSuite {
         "applications" - {
           "should select default given no application" - {
             Deployment
-              .generate(annotations.copy(applications = Vector("test" -> Vector("arg1", "arg2"), "default" -> Vector("def1"))), "apps/v1beta2", None, imageName, Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false)
+              .generate(annotations.copy(applications = Vector("test" -> Vector("arg1", "arg2"), "default" -> Vector("def1"))), "apps/v1beta2", None, imageName, PodTemplate.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false)
               .toOption
               .get
               .payload
@@ -393,7 +394,7 @@ object DeploymentJsonTest extends TestSuite {
 
           "should select requested application given an application" - {
             Deployment
-              .generate(annotations.copy(applications = Vector("test" -> Vector("arg1", "arg2"), "default" -> Vector("def1"))), "apps/v1beta2", Some("test"), imageName, Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false)
+              .generate(annotations.copy(applications = Vector("test" -> Vector("arg1", "arg2"), "default" -> Vector("def1"))), "apps/v1beta2", Some("test"), imageName, PodTemplate.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false)
               .toOption
               .get
               .payload
@@ -427,7 +428,7 @@ object DeploymentJsonTest extends TestSuite {
 
           val generatedJson =
             Deployment
-              .generate(annotations, "apps/v1beta2", None, imageName, Deployment.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false)
+              .generate(annotations, "apps/v1beta2", None, imageName, PodTemplate.ImagePullPolicy.Never, 1, Map.empty, CanaryDeploymentType, None, false)
               .toOption
               .get
               .payload

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
@@ -27,6 +27,7 @@ import Argonaut._
 object IngressJsonTest extends TestSuite {
   val annotations = Annotations(
     namespace = Some("chirper"),
+    applications = Vector.empty,
     appName = Some("friendservice"),
     appType = None,
     configResource = None,

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.runtime.kubernetes
+
+import argonaut._
+import com.lightbend.rp.reactivecli.annotations.{ Annotations, LiteralEnvironmentVariable, Secret }
+import com.lightbend.rp.reactivecli.argparse.CanaryDeploymentType
+import scala.collection.immutable.Seq
+import utest._
+
+import Argonaut._
+
+object JobJsonTest extends TestSuite {
+  val tests = this{
+    "works" - {
+      val annotations = Annotations(
+        namespace = None,
+        applications = Vector.empty,
+        appName = Some("friendimpl"),
+        appType = Some("basic"),
+        configResource = None,
+        diskSpace = None,
+        memory = None,
+        cpu = None,
+        endpoints = Map.empty,
+        secrets = Seq.empty,
+        privileged = false,
+        environmentVariables = Map.empty,
+        version = Some("3.2.1-SNAPSHOT"),
+        modules = Set.empty,
+        akkaClusterBootstrapSystemName = None)
+
+      val job =
+        Job.generate(
+          annotations,
+          "batch/v1",
+          None,
+          "test/testing:1.0.0",
+          PodTemplate.ImagePullPolicy.Always,
+          noOfReplicas = 1,
+          Map.empty,
+          CanaryDeploymentType,
+          None,
+          true)
+
+      val json = job.toOption.get.json
+
+      val expected = jObjectFields(
+        "apiVersion" -> jString("batch/v1"),
+        "kind" -> jString("Job"),
+        "metadata" -> jObjectFields(
+          "name" -> jString("friendimpl-v3-2-1-snapshot"),
+          "labels" -> jObjectFields(
+            "appName" -> jString("friendimpl"),
+            "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"))),
+        "spec" -> jObjectFields(
+          "template" -> jObjectFields(
+            "metadata" -> jObjectFields(
+              "labels" -> jObjectFields(
+                "appName" -> jString("friendimpl"),
+                "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"))),
+            "spec" -> jObjectFields(
+              "restartPolicy" -> jString("OnFailure"),
+              "containers" -> jArrayElements(
+                jObjectFields(
+                  "name" -> jString("friendimpl"),
+                  "image" -> jString("test/testing:1.0.0"),
+                  "ports" -> jEmptyArray,
+                  "imagePullPolicy" -> jString("Always"),
+                  "volumeMounts" -> jEmptyArray,
+                  "env" -> jArrayElements(
+                    jObjectFields("name" -> jString("RP_APP_NAME"), "value" -> jString("friendimpl")),
+                    jObjectFields("name" -> jString("RP_APP_TYPE"), "value" -> jString("basic")),
+                    jObjectFields("name" -> jString("RP_APP_VERSION"), "value" -> jString("3.2.1-SNAPSHOT")),
+                    jObjectFields("name" -> jString("RP_ENDPOINTS_COUNT"), "value" -> jString("0")),
+                    jObjectFields("name" -> jString("RP_KUBERNETES_POD_IP"), "valueFrom" -> jObjectFields("fieldRef" -> jObjectFields("fieldPath" -> jString("status.podIP")))),
+                    jObjectFields("name" -> jString("RP_KUBERNETES_POD_NAME"), "valueFrom" -> jObjectFields("fieldRef" -> jObjectFields("fieldPath" -> jString("metadata.name")))),
+                    jObjectFields("name" -> jString("RP_PLATFORM"), "value" -> jString("kubernetes"))))),
+              "volumes" -> jEmptyArray))))
+
+      assert(json == expected)
+    }
+  }
+}

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/NamespaceJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/NamespaceJsonTest.scala
@@ -30,6 +30,7 @@ object NamespaceJsonTest extends TestSuite {
     "json serialization" - {
       val annotations = Annotations(
         namespace = None,
+        applications = Vector.empty,
         appName = None,
         appType = None,
         configResource = None,

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
@@ -29,6 +29,7 @@ object ServiceJsonTest extends TestSuite {
 
   val annotations = Annotations(
     namespace = Some("chirper"),
+    applications = Vector.empty,
     appName = Some("friendimpl"),
     appType = None,
     configResource = None,

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -201,8 +201,7 @@ object MuslBuild {
       override protected def preBuildHook: String = preBuild
 
       override protected def sbtBuildArgumentsHook: String = sbtBuildArguments
-    }
-  )
+    })
 }
 
 case class BuildInfo(name: String, baseImage: String, install: String, target: BuildTarget) {

--- a/project/BuildTarget.scala
+++ b/project/BuildTarget.scala
@@ -225,7 +225,7 @@ case class TarGzSelfContainedExecutableBuildTarget(libs: Seq[String]) extends Bu
   val architecture = "amd64"
 
   override def launcherExecHook: String = "exec $DIR/lib/ld-musl-x86_64.so.1"
-  
+
   def prepare(stage: File, info: BuildInfo, version: String): Unit = {
     val libPathToName = parseLibs(libs)
 


### PR DESCRIPTION
Complementing https://github.com/lightbend/sbt-reactive-app/pull/7

* This allows an operator to specify `--application <name>` to select from one of a number of applications inside the Docker image.
* Adds a `--name` flag is provided to allow operator to change the name of the generated resources, similar to the `--version` flag.
* Adds a `--pod-controller-type` flag with values `deployment` and `job` that can be used to allow an operator to generate a job. Since `Deployment` and `Job` are very similar, much of the code was extracted to a new `PodTemplate` class. This puts us in a good position to easily deliver `StatefulSet` as another pod controller type.