### PR TITLE
Specify initialDelaySeconds for livenessProbe

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -312,7 +312,8 @@ object PodTemplate {
             "httpGet" -> Json(
               "path" -> jString("/platform-tooling/healthy"),
               "port" -> jString(AkkaManagementPortName)),
-            "periodSeconds" -> jNumber(StatusPeriodSeconds)))
+            "periodSeconds" -> jNumber(StatusPeriodSeconds),
+            "initialDelaySeconds" -> jNumber(LivenessInitialDelaySeconds)))
       else
         jEmptyObject
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -34,6 +34,7 @@ import Scalaz._
 
 package object kubernetes extends LazyLogging {
   private[reactivecli] val AkkaClusterMinimumReplicas = 2
+  private[reactivecli] val LivenessInitialDelaySeconds = 60
   private[reactivecli] val StatusPeriodSeconds = 10
 
   /**


### PR DESCRIPTION
This ensures that `initialDelaySeconds` is set to an appropriate value. I think 60 seconds is good for now, we can perhaps make this inferred in the future depending upon enabled features.

60 seconds chosen due to 40 seconds allotted to join seed nodes: https://github.com/lightbend/reactive-lib/pull/45