### PR TITLE
Multiple Docker images, Ingress merging

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/annotations/Annotations.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/annotations/Annotations.scala
@@ -126,7 +126,8 @@ object Annotations extends LazyLogging {
 
   private[annotations] def namespace(args: GenerateDeploymentArgs): Option[String] =
     args.targetRuntimeArgs.collect {
-      case KubernetesArgs(_, _, _, _, _, _, _, _, Some(namespace), _, _, _, _) => namespace
+      case args: KubernetesArgs if args.namespace.isDefined =>
+        args.namespace.get
     }
 
   private[annotations] def applications(applications: Seq[Map[String, String]]): Seq[(String, Seq[String])] =

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -65,7 +65,7 @@ case object RollingDeploymentType extends DeploymentType
 case class GenerateDeploymentArgs(
   application: Option[String] = None,
   deploymentType: DeploymentType = CanaryDeploymentType,
-  dockerImage: Option[String] = None,
+  dockerImages: Seq[String] = Seq.empty,
   name: Option[String] = None,
   version: Option[String] = None,
   environmentVariables: Map[String, String] = Map.empty,

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/IngressArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/IngressArgs.scala
@@ -17,6 +17,7 @@
 package com.lightbend.rp.reactivecli.argparse.kubernetes
 
 import com.lightbend.rp.reactivecli.argparse.InputArgs
+import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
 object IngressArgs {
@@ -39,5 +40,7 @@ object IngressArgs {
  */
 case class IngressArgs(
   apiVersion: Future[String] = KubernetesArgs.DefaultIngressApiVersion,
+  hosts: Seq[String] = Seq.empty,
   ingressAnnotations: Map[String, String] = Map.empty,
+  name: Option[String] = None,
   pathAppend: Option[String] = None)

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/KubernetesArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/KubernetesArgs.scala
@@ -84,19 +84,4 @@ case class KubernetesArgs(
   podControllerArgs: PodControllerArgs = PodControllerArgs(),
   serviceArgs: ServiceArgs = ServiceArgs(),
   ingressArgs: IngressArgs = IngressArgs(),
-  output: KubernetesArgs.Output = KubernetesArgs.Output.PipeToStream(System.out)) extends TargetRuntimeArgs {
-  def generateAll: Boolean =
-    !generateIngress && !generatePodControllers && !generateServices
-
-  def shouldGenerateIngress: Boolean =
-    generateIngress || generateAll
-
-  def shouldGenerateNamespaces: Boolean =
-    generateNamespaces
-
-  def shouldGeneratePodControllers: Boolean =
-    generatePodControllers || generateAll
-
-  def shouldGenerateServices: Boolean =
-    generateServices || generateAll
-}
+  output: KubernetesArgs.Output = KubernetesArgs.Output.PipeToStream(System.out)) extends TargetRuntimeArgs

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/process/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/process/package.scala
@@ -23,6 +23,6 @@ package object process extends LazyLogging {
   def exec(args: String*): Future[(Int, String)] =
     Platform.processExec(Seq(args: _*))
 
-  def execWithStdinFile(args: Seq[String], stdinFile: Option[String]) : Future[(Int, String)] =
+  def execWithStdinFile(args: Seq[String], stdinFile: Option[String]): Future[(Int, String)] =
     Platform.processExec(args, stdinFile)
 }

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -34,18 +34,32 @@ object InputArgsTest extends TestSuite {
     "argument parsing" - {
       "generate deployment" - {
         "kubernetes" - {
-          "minimum arguments" - {
+          "fail without generate flags" - {
             val result = parser.parse(
               Seq(
                 "generate-kubernetes-resources",
                 "dockercloud/hello-world:1.0.0-SNAPSHOT"),
               InputArgs.default)
+            assert(result.isEmpty)
+          }
+
+          "minimum arguments" - {
+            val result = parser.parse(
+              Seq(
+                "generate-kubernetes-resources",
+                "dockercloud/hello-world:1.0.0-SNAPSHOT",
+                "--generate-all"),
+              InputArgs.default)
             assert(
               result.contains(
                 InputArgs(
                   commandArgs = Some(GenerateDeploymentArgs(
-                    dockerImage = Some("dockercloud/hello-world:1.0.0-SNAPSHOT"),
-                    targetRuntimeArgs = Some(KubernetesArgs()))))))
+                    dockerImages = Seq("dockercloud/hello-world:1.0.0-SNAPSHOT"),
+                    targetRuntimeArgs = Some(
+                      KubernetesArgs(
+                        generateIngress = true,
+                        generatePodControllers = true,
+                        generateServices = true)))))))
           }
 
           "all arguments" - {
@@ -100,7 +114,7 @@ object InputArgsTest extends TestSuite {
 
                 assert(commandArgs.name == Some("test"))
                 assert(commandArgs.deploymentType == RollingDeploymentType)
-                assert(commandArgs.dockerImage == Some("dockercloud/hello-world:1.0.0-SNAPSHOT"))
+                assert(commandArgs.dockerImages == Seq("dockercloud/hello-world:1.0.0-SNAPSHOT"))
                 assert(commandArgs.environmentVariables == Map("test1" -> "test2"))
                 assert(commandArgs.registryUsername == Some("john"))
                 assert(commandArgs.registryPassword == Some("wick"))


### PR DESCRIPTION
* modifies `generate-kubernetes-resources` to take 1 or more Docker images and generate resources for all of them.
* adds a merging pipeline that reduces multiple `Ingress` resources into one, reverse sorted by path complexity. This is required to make ingress work on all ingress controllers out there -- many of them only want one for a given host.
* when multiple `Ingress` resources are generated (i.e. >= 2), the operator must also provide a value for the `--ingress-name` flag.
* when parsing command line arguments fails, we now exit 1 instead of 0.
* the types of resources generated now need to be specified by default, i.e. the operator must specify one of `--generate-all`, `--generate-pod-controllers`, `--generate-services`, `--generate-ingress`.
* adds an `--ingress-host` flag that can be used to add hosts to the generated ingress resources.

- [x] manual test concept on bluemix
- [x] initial impl
- [x] sort urls 
- [x] improve merging
- [x] unit tests

Fixes #107 
Fixes #105 