### PR TITLE
Remove clusterIP default to None

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
@@ -87,9 +87,9 @@ object Service {
                 .deepmerge(
                   annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> serviceName(ns).asJson))),
               "spec" -> Json(
-                "clusterIP" -> clusterIp.getOrElse("None").asJson,
                 "ports" -> annotations.endpoints.asJson,
-                "selector" -> selector)),
+                "selector" -> selector).deepmerge(
+                  clusterIp.fold(jEmptyObject)(cIp => Json("clusterIP" -> jString(cIp))))),
             jqExpression))
     }
 }

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
@@ -375,7 +375,6 @@ object KubernetesPackageTest extends TestSuite {
                   |    "namespace": "chirper"
                   |  },
                   |  "spec": {
-                  |    "clusterIP": "None",
                   |    "ports": [
                   |      {
                   |        "name": "ep1",

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
@@ -117,7 +117,6 @@ object ServiceJsonTest extends TestSuite {
               |    "namespace": "chirper"
               |  },
               |  "spec": {
-              |    "clusterIP": "None",
               |    "ports": [
               |      {
               |        "name": "ep1",


### PR DESCRIPTION
Fixes #110 

We shouldn't do anything with clusterIP unless explicitly set by the user via `--service-cluster-ip`.

Verified working on Bluemix and Minikube.