### PR TITLE
Add hidden --akka-cluster-skip-validation flag

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -99,7 +99,7 @@ object Main extends LazyLogging {
                   System.out.println(s"jq support: ${if (jqAvail) "Available" else "Unavailable"}")
                 }
 
-              case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, _, _, _, _, _, Some(kubernetesArgs: KubernetesArgs), _, _, _, _, _) =>
+              case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, _, _, _, _, _, _, Some(kubernetesArgs: KubernetesArgs), _, _, _, _, _) =>
                 implicit val httpSettings: HttpSettings =
                   inputArgs.tlsCacertsPath.fold(HttpSettings.default)(v => HttpSettings.default.copy(tlsCacertsPath = Some(v)))
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -64,6 +64,8 @@ case object RollingDeploymentType extends DeploymentType
  */
 case class GenerateDeploymentArgs(
   application: Option[String] = None,
+  akkaClusterJoinExisting: Boolean = false,
+  akkaClusterSkipValidation: Boolean = false,
   deploymentType: DeploymentType = CanaryDeploymentType,
   dockerImages: Seq[String] = Seq.empty,
   name: Option[String] = None,
@@ -72,7 +74,6 @@ case class GenerateDeploymentArgs(
   cpu: Option[Double] = None,
   memory: Option[Long] = None,
   diskSpace: Option[Long] = None,
-  joinExistingAkkaCluster: Boolean = false,
   targetRuntimeArgs: Option[TargetRuntimeArgs] = None,
   registryUsername: Option[String] = None,
   registryPassword: Option[String] = None,

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -193,9 +193,13 @@ object InputArgs {
             .text("Appends the expression specified to the paths of the generated Ingress resources")
             .action(IngressArgs.set((v, c) => c.copy(pathAppend = Some(v)))),
 
-          opt[Unit]("join-existing-akka-cluster")
+          opt[Unit]("akka-cluster-join-existing")
             .text("When provided, the pod controller will only join an already formed Akka Cluster")
-            .action(GenerateDeploymentArgs.set((_, args) => args.copy(joinExistingAkkaCluster = true))),
+            .action(GenerateDeploymentArgs.set((_, args) => args.copy(akkaClusterJoinExisting = true))),
+
+          opt[Unit]("akka-cluster-skip-validation")
+            .hidden()
+            .action(GenerateDeploymentArgs.set((_, args) => args.copy(akkaClusterSkipValidation = true))),
 
           opt[String]("name")
             .text("Uses specified name for generated resources instead of name in the Docker image")
@@ -226,7 +230,7 @@ object InputArgs {
             .action(PodControllerArgs.set((v, args) => args.copy(imagePullPolicy = v))),
 
           opt[Int]("pod-controller-replicas")
-            .text("Sets the number of replicas for the Pod Controller resources. If Akka Cluster Bootstrap is enabled, this must be set to 2 or greater unless `--join-existing-akka-cluster` is provided")
+            .text("Sets the number of replicas for the Pod Controller resources. If Akka Cluster Bootstrap is enabled, this must be set to 2 or greater unless `--akka-cluster-join-existing` is provided")
             .validate(v => if (v >= 0) success else failure("Number of replicas must be zero or more"))
             .action(PodControllerArgs.set((v, args) => args.copy(numberOfReplicas = v))),
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
@@ -40,7 +40,7 @@ object Deployment {
     externalServices: Map[String, Seq[String]],
     deploymentType: DeploymentType,
     jqExpression: Option[String],
-    joinExistingAkkaCluster: Boolean): ValidationNel[String, Deployment] =
+    akkaClusterJoinExisting: Boolean): ValidationNel[String, Deployment] =
 
     (annotations.applicationValidation(application) |@| annotations.appNameValidation |@| annotations.versionValidation) { (applicationArgs, rawAppName, version) =>
       val appName = serviceName(rawAppName)
@@ -61,7 +61,7 @@ object Deployment {
           RestartPolicy.Always,
           externalServices,
           deploymentType,
-          joinExistingAkkaCluster,
+          akkaClusterJoinExisting,
           applicationArgs,
           appName,
           appNameVersion,

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
@@ -40,7 +40,7 @@ object Job {
     externalServices: Map[String, Seq[String]],
     deploymentType: DeploymentType,
     jqExpression: Option[String],
-    joinExistingAkkaCluster: Boolean): ValidationNel[String, Job] =
+    akkaClusterJoinExisting: Boolean): ValidationNel[String, Job] =
 
     (annotations.applicationValidation(application) |@| annotations.appNameValidation |@| annotations.versionValidation) { (applicationArgs, rawAppName, version) =>
       val appName = serviceName(rawAppName)
@@ -61,7 +61,7 @@ object Job {
           RestartPolicy.OnFailure,
           externalServices,
           deploymentType,
-          joinExistingAkkaCluster,
+          akkaClusterJoinExisting,
           applicationArgs,
           appName,
           appNameVersion,

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -91,7 +91,7 @@ package object kubernetes extends LazyLogging {
               generateDeploymentArgs.externalServices,
               generateDeploymentArgs.deploymentType,
               kubernetesArgs.transformPodControllers,
-              generateDeploymentArgs.joinExistingAkkaCluster)
+              generateDeploymentArgs.akkaClusterJoinExisting)
 
           case PodControllerArgs.ControllerType.Job =>
             Job.generate(
@@ -104,7 +104,7 @@ package object kubernetes extends LazyLogging {
               generateDeploymentArgs.externalServices,
               generateDeploymentArgs.deploymentType,
               kubernetesArgs.transformPodControllers,
-              generateDeploymentArgs.joinExistingAkkaCluster)
+              generateDeploymentArgs.akkaClusterJoinExisting)
         }
 
       val services = Service.generate(
@@ -125,8 +125,8 @@ package object kubernetes extends LazyLogging {
         kubernetesArgs.ingressArgs.pathAppend)
 
       val validateAkkaCluster =
-        if (annotations.modules.contains(Module.AkkaClusterBootstrapping) && kubernetesArgs.podControllerArgs.numberOfReplicas < AkkaClusterMinimumReplicas && !generateDeploymentArgs.joinExistingAkkaCluster && kubernetesArgs.generatePodControllers)
-          s"Akka Cluster Bootstrapping is enabled so you must specify `--pod-controller-replicas 2` (or greater), or provide `--join-existing-akka-cluster` to only join already formed clusters".failureNel
+        if (annotations.modules.contains(Module.AkkaClusterBootstrapping) && !generateDeploymentArgs.akkaClusterSkipValidation && kubernetesArgs.podControllerArgs.numberOfReplicas < AkkaClusterMinimumReplicas && !generateDeploymentArgs.akkaClusterJoinExisting && kubernetesArgs.generatePodControllers)
+          s"Akka Cluster Bootstrapping is enabled so you must specify `--pod-controller-replicas 2` (or greater), or provide `--akka-cluster-join-existing` to only join already formed clusters".failureNel
         else
           ().successNel[String]
 

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -96,7 +96,8 @@ object InputArgsTest extends TestSuite {
                     "--generate-pod-controllers",
                     "--generate-services",
                     "--deployment-type", "rolling",
-                    "--join-existing-akka-cluster",
+                    "--akka-cluster-join-existing",
+                    "--akka-cluster-skip-validation",
                     "--name", "test",
                     "--pod-controller-type", "job"),
                   InputArgs.default)
@@ -121,7 +122,8 @@ object InputArgsTest extends TestSuite {
                 assert(!commandArgs.registryUseHttps)
                 assert(!commandArgs.registryValidateTls)
                 assert(commandArgs.externalServices == Map("cas1" -> Seq("1.2.3.4", "5.6.7.8"), "cas2" -> Seq("hello")))
-                assert(commandArgs.joinExistingAkkaCluster)
+                assert(commandArgs.akkaClusterJoinExisting)
+                assert(commandArgs.akkaClusterSkipValidation)
 
                 assert(targetRuntimeArgs.generateIngress)
                 assert(targetRuntimeArgs.generateNamespaces)

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
@@ -492,7 +492,7 @@ object KubernetesPackageTest extends TestSuite {
 
                 val message = failed.head
 
-                val expected = "Akka Cluster Bootstrapping is enabled so you must specify `--pod-controller-replicas 2` (or greater), or provide `--join-existing-akka-cluster` to only join already formed clusters"
+                val expected = "Akka Cluster Bootstrapping is enabled so you must specify `--pod-controller-replicas 2` (or greater), or provide `--akka-cluster-join-existing` to only join already formed clusters"
 
                 assert(message == expected)
               }
@@ -503,7 +503,7 @@ object KubernetesPackageTest extends TestSuite {
               imageName,
               dockerConfig.copy(config = dockerConfig.config.copy(Labels = dockerConfig.config.Labels.map(_ ++ Vector(
                 "com.lightbend.rp.modules.akka-cluster-bootstrapping.enabled" -> "true")))),
-              generateDeploymentArgs.copy(joinExistingAkkaCluster = true),
+              generateDeploymentArgs.copy(akkaClusterJoinExisting = true),
               kubernetesArgs.copy(generateIngress = true))
               .map { result =>
                 assert(result.isSuccess)


### PR DESCRIPTION
This adds a hidden flag `--akka-cluster-skip-validation` which can be used to allow a cluster to start with only one contact point.

Use-case: `sbt deploy minikube` which I'd like to alter to only deploy a single service by default, thus avoiding Cassandra keyspace/table initialization race.

It also renames `--join-existing-akka-cluster` to `--akka-cluster-join-existing` -- I think this naming convention will be more manageable as more options are added in the future.