### PR TITLE
GKE fixes

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -265,8 +265,16 @@ object InputArgs {
             .action(ServiceArgs.set((v, args) => args.copy(apiVersion = Future.successful(v)))),
 
           opt[String]("service-cluster-ip")
-            .text("Sets the cluster IP for Service resources")
+            .text("Sets the clusterIP value for Service resources")
             .action(ServiceArgs.set((v, args) => args.copy(clusterIp = Some(v)))),
+
+          opt[String]("service-load-balancer-ip")
+            .text("Sets the loadBalancerIP for Service resources")
+            .action(ServiceArgs.set((v, args) => args.copy(loadBalancerIp = Some(v)))),
+
+          opt[String]("service-type")
+            .text("Sets the type for Service resources")
+            .action(ServiceArgs.set((v, args) => args.copy(serviceType = Some(v)))),
 
           opt[String]("version")
             .text("Uses specified version tag for generated resources instead of version in the docker image")

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/ServiceArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/ServiceArgs.scala
@@ -37,4 +37,4 @@ object ServiceArgs {
 /**
  * Represents user input arguments required to build Kubernetes Service resource.
  */
-case class ServiceArgs(apiVersion: Future[String] = KubernetesArgs.DefaultServiceApiVersion, clusterIp: Option[String] = None)
+case class ServiceArgs(apiVersion: Future[String] = KubernetesArgs.DefaultServiceApiVersion, clusterIp: Option[String] = None, loadBalancerIp: Option[String] = None, serviceType: Option[String] = None)

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/Image.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/Image.scala
@@ -24,4 +24,7 @@ case class Image(
   providedUrl: Option[String],
   providedNamespace: Option[String],
   providedImage: String,
-  providedTag: Option[String])
+  providedTag: Option[String]) {
+
+  def pullScope: String = s"repository:$namespace/$image:pull"
+}

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
@@ -58,7 +58,9 @@ object Service {
     apiVersion: String,
     clusterIp: Option[String],
     deploymentType: DeploymentType,
-    jqExpression: Option[String]): ValidationNel[String, Option[Service]] =
+    jqExpression: Option[String],
+    loadBalancerIp: Option[String],
+    serviceType: Option[String]): ValidationNel[String, Option[Service]] =
     (annotations.appNameValidation |@| annotations.versionValidation) { (rawAppName, version) =>
       // FIXME there's a bit of code duplicate in Deployment
       val appName = serviceName(rawAppName)
@@ -88,8 +90,10 @@ object Service {
                   annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> serviceName(ns).asJson))),
               "spec" -> Json(
                 "ports" -> annotations.endpoints.asJson,
-                "selector" -> selector).deepmerge(
-                  clusterIp.fold(jEmptyObject)(cIp => Json("clusterIP" -> jString(cIp))))),
+                "selector" -> selector)
+                .deepmerge(clusterIp.fold(jEmptyObject)(cIp => Json("clusterIP" -> jString(cIp))))
+                .deepmerge(serviceType.fold(jEmptyObject)(svcType => Json("type" -> jString(svcType))))
+                .deepmerge(loadBalancerIp.fold(jEmptyObject)(lbIp => Json("loadBalancerIP" -> jString(lbIp))))),
             jqExpression))
     }
 }

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -112,7 +112,9 @@ package object kubernetes extends LazyLogging {
         serviceApiVersion,
         kubernetesArgs.serviceArgs.clusterIp,
         generateDeploymentArgs.deploymentType,
-        kubernetesArgs.transformServices)
+        kubernetesArgs.transformServices,
+        kubernetesArgs.serviceArgs.loadBalancerIp,
+        kubernetesArgs.serviceArgs.serviceType)
       val ingress = Ingress.generate(
         annotations,
         ingressApiVersion,
@@ -122,6 +124,7 @@ package object kubernetes extends LazyLogging {
           None,
         kubernetesArgs.ingressArgs.ingressAnnotations,
         kubernetesArgs.transformIngress,
+        kubernetesArgs.ingressArgs.name,
         kubernetesArgs.ingressArgs.pathAppend)
 
       val validateAkkaCluster =

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -99,7 +99,9 @@ object InputArgsTest extends TestSuite {
                     "--akka-cluster-join-existing",
                     "--akka-cluster-skip-validation",
                     "--name", "test",
-                    "--pod-controller-type", "job"),
+                    "--pod-controller-type", "job",
+                    "--service-type", "NodePort",
+                    "--service-load-balancer-ip", "10.0.0.2"),
                   InputArgs.default)
                 .get
 
@@ -136,6 +138,8 @@ object InputArgsTest extends TestSuite {
                 assert(targetRuntimeArgs.podControllerArgs.numberOfReplicas == 10)
                 assert(targetRuntimeArgs.serviceArgs.apiVersion.value.get.get == "hello3")
                 assert(targetRuntimeArgs.serviceArgs.clusterIp == Some("10.0.0.1"))
+                assert(targetRuntimeArgs.serviceArgs.loadBalancerIp == Some("10.0.0.2"))
+                assert(targetRuntimeArgs.serviceArgs.serviceType == Some("NodePort"))
                 assert(targetRuntimeArgs.ingressArgs.apiVersion.value.get.get == "hello2")
                 assert(targetRuntimeArgs.ingressArgs.ingressAnnotations == Map("ing" -> "123"))
                 assert(targetRuntimeArgs.ingressArgs.pathAppend == Some(".*"))

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
@@ -52,7 +52,7 @@ object IngressJsonTest extends TestSuite {
       modules = Set.empty,
       akkaClusterBootstrapSystemName = None)
 
-  val annotations = createAnnotations("friendservice", "/api/friend", "/api/enemy")
+  val annotations = createAnnotations("friendservice", "/api/friend/", "/api/enemy")
 
   val tests = this{
     "json serialization" - {
@@ -62,6 +62,7 @@ object IngressJsonTest extends TestSuite {
           "extensions/v1beta1",
           None,
           ingressAnnotations = Map.empty,
+          None,
           None,
           pathAppend = Option.empty).toOption.get
         val expectedJson =
@@ -79,7 +80,7 @@ object IngressJsonTest extends TestSuite {
             |        "http" : {
             |          "paths" : [
             |            {
-            |              "path" : "/api/friend",
+            |              "path" : "/api/friend/",
             |              "backend" : {
             |                "serviceName" : "friendservice",
             |                "servicePort" : 1234
@@ -93,7 +94,7 @@ object IngressJsonTest extends TestSuite {
             |        "http" : {
             |          "paths" : [
             |            {
-            |              "path" : "/api/friend",
+            |              "path" : "/api/friend/",
             |              "backend" : {
             |                "serviceName" : "friendservice",
             |                "servicePort" : 1234
@@ -120,7 +121,7 @@ object IngressJsonTest extends TestSuite {
             |        "http" : {
             |          "paths" : [
             |            {
-            |              "path" : "/api/friend",
+            |              "path" : "/api/friend/",
             |              "backend" : {
             |                "serviceName" : "friendservice",
             |                "servicePort" : 1234
@@ -151,7 +152,8 @@ object IngressJsonTest extends TestSuite {
           Some(Vector("test.com")),
           ingressAnnotations = Map("kubernetes.io/ingress.class" -> "istio"),
           None,
-          pathAppend = Some(".*")).toOption.get
+          None,
+          pathAppend = Some("/.*")).toOption.get
 
         val expectedJson =
           """
@@ -172,14 +174,14 @@ object IngressJsonTest extends TestSuite {
             |        "http" : {
             |          "paths" : [
             |            {
-            |              "path" : "/api/friend.*",
+            |              "path" : "/api/friend/.*",
             |              "backend" : {
             |                "serviceName" : "friendservice",
             |                "servicePort" : 1234
             |              }
             |            },
             |            {
-            |              "path" : "/api/enemy.*",
+            |              "path" : "/api/enemy/.*",
             |              "backend" : {
             |                "serviceName" : "friendservice",
             |                "servicePort" : 1234
@@ -203,12 +205,12 @@ object IngressJsonTest extends TestSuite {
       }
 
       "should fail if application name is not defined" - {
-        assert(Ingress.generate(annotations.copy(appName = None), "extensions/v1beta1", None, Map.empty, None, Option.empty).toOption.isEmpty)
+        assert(Ingress.generate(annotations.copy(appName = None), "extensions/v1beta1", None, Map.empty, None, None, Option.empty).toOption.isEmpty)
       }
 
       "jq" - {
         Ingress
-          .generate(annotations.copy(appName = Some("test")), "extensions/v1beta1", None, Map.empty, Some(".jqTest = \"test\""), Option.empty)
+          .generate(annotations.copy(appName = Some("test")), "extensions/v1beta1", None, Map.empty, Some(".jqTest = \"test\""), None, Option.empty)
           .toOption
           .get
           .get
@@ -223,6 +225,7 @@ object IngressJsonTest extends TestSuite {
           Some(Vector("test.com")),
           ingressAnnotations = Map("kubernetes.io/ingress.class" -> "istio"),
           None,
+          None,
           None).toOption.get.get
 
         val b = Ingress.generate(
@@ -230,6 +233,7 @@ object IngressJsonTest extends TestSuite {
           "extensions/v1beta1",
           Some(Vector("test.com")),
           ingressAnnotations = Map("kubernetes.io/ingress.class" -> "istio2"),
+          None,
           None,
           None).toOption.get.get
 
@@ -266,7 +270,7 @@ object IngressJsonTest extends TestSuite {
                           }
                         },
                         {
-                          "path" : "/api/friend",
+                          "path" : "/api/friend/",
                           "backend" : {
                             "serviceName" : "friendservice",
                             "servicePort" : 1234


### PR DESCRIPTION
Various fixes that came out of testing on GKE:

* GKE registry, when responding 401 with a `Www-Authenticate`, don't calculate the scope for you. This adds a fallback scope to handle that case.
* Path suffix shouldn't result in duplicate slashes, i.e. normalize `/hello//*` to `/hello/*`
* Add `--service-type` flag
* Add `--service-load-balancer-ip` flag