### PR TITLE
add flag for adding tls secrets to ingress resources

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -18,7 +18,7 @@ package com.lightbend.rp.reactivecli.argparse
 
 import com.lightbend.rp.reactivecli.argparse.kubernetes._
 import com.lightbend.rp.reactivecli.files._
-import com.lightbend.rp.reactivecli.runtime.kubernetes.PodTemplate.{ImagePullPolicy, RestartPolicy}
+import com.lightbend.rp.reactivecli.runtime.kubernetes.PodTemplate.{ ImagePullPolicy, RestartPolicy }
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scopt.OptionParser
@@ -195,6 +195,12 @@ object InputArgs {
           opt[String]("ingress-path-suffix")
             .text("Appends the expression specified to the paths of the generated Ingress resources")
             .action(IngressArgs.set((v, c) => c.copy(pathAppend = Some(v)))),
+
+          opt[String]("ingress-tls-secret")
+            .minOccurs(0)
+            .unbounded()
+            .text("Add a TLS secret to the generated Ingress resources ")
+            .action(IngressArgs.set((v, c) => c.copy(tlsSecrets = c.tlsSecrets :+ v))),
 
           opt[Unit]("akka-cluster-join-existing")
             .text("When provided, the pod controller will only join an already formed Akka Cluster")

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/IngressArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/kubernetes/IngressArgs.scala
@@ -43,4 +43,5 @@ case class IngressArgs(
   hosts: Seq[String] = Seq.empty,
   ingressAnnotations: Map[String, String] = Map.empty,
   name: Option[String] = None,
-  pathAppend: Option[String] = None)
+  pathAppend: Option[String] = None,
+  tlsSecrets: Seq[String] = Seq.empty)

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
@@ -53,58 +53,58 @@ object Deployment {
       |@| annotations.appNameValidation
       |@| annotations.versionValidation
       |@| restartPolicyValidation(restartPolicy)) { (applicationArgs, rawAppName, version, restartPolicy) =>
-      val appName = serviceName(rawAppName)
-      val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
+        val appName = serviceName(rawAppName)
+        val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
 
-      val labels = Map(
-        "appName" -> appName,
-        "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
+        val labels = Map(
+          "appName" -> appName,
+          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
 
-      val podTemplate =
-        PodTemplate.generate(
-          annotations,
-          apiVersion,
-          application,
-          imageName,
-          imagePullPolicy,
-          noOfReplicas,
-          RestartPolicy.Always, // The only valid RestartPolicy for Deployment
-          externalServices,
-          deploymentType,
-          akkaClusterJoinExisting,
-          applicationArgs,
-          appName,
-          appNameVersion,
-          labels)
+        val podTemplate =
+          PodTemplate.generate(
+            annotations,
+            apiVersion,
+            application,
+            imageName,
+            imagePullPolicy,
+            noOfReplicas,
+            RestartPolicy.Always, // The only valid RestartPolicy for Deployment
+            externalServices,
+            deploymentType,
+            akkaClusterJoinExisting,
+            applicationArgs,
+            appName,
+            appNameVersion,
+            labels)
 
-      val (deploymentName, deploymentMatchLabels) =
-        deploymentType match {
-          case CanaryDeploymentType =>
-            (appNameVersion, Json("appNameVersion" -> appNameVersion.asJson))
+        val (deploymentName, deploymentMatchLabels) =
+          deploymentType match {
+            case CanaryDeploymentType =>
+              (appNameVersion, Json("appNameVersion" -> appNameVersion.asJson))
 
-          case BlueGreenDeploymentType =>
-            (appNameVersion, Json("appNameVersion" -> appNameVersion.asJson))
+            case BlueGreenDeploymentType =>
+              (appNameVersion, Json("appNameVersion" -> appNameVersion.asJson))
 
-          case RollingDeploymentType =>
-            (appName, Json("appName" -> appName.asJson))
-        }
+            case RollingDeploymentType =>
+              (appName, Json("appName" -> appName.asJson))
+          }
 
-      Deployment(
-        deploymentName,
-        Json(
-          "apiVersion" -> apiVersion.asJson,
-          "kind" -> "Deployment".asJson,
-          "metadata" -> Json(
-            "name" -> deploymentName.asJson,
-            "labels" -> labels.asJson)
-            .deepmerge(
-              annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> serviceName(ns).asJson))),
-          "spec" -> Json(
-            "replicas" -> noOfReplicas.asJson,
-            "selector" -> Json("matchLabels" -> deploymentMatchLabels),
-            "template" -> podTemplate.json)),
-        jqExpression)
-    }
+        Deployment(
+          deploymentName,
+          Json(
+            "apiVersion" -> apiVersion.asJson,
+            "kind" -> "Deployment".asJson,
+            "metadata" -> Json(
+              "name" -> deploymentName.asJson,
+              "labels" -> labels.asJson)
+              .deepmerge(
+                annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> serviceName(ns).asJson))),
+            "spec" -> Json(
+              "replicas" -> noOfReplicas.asJson,
+              "selector" -> Json("matchLabels" -> deploymentMatchLabels),
+              "template" -> podTemplate.json)),
+          jqExpression)
+      }
 }
 
 /**

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Ingress.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Ingress.scala
@@ -121,7 +121,8 @@ object Ingress {
     ingressAnnotations: Map[String, String],
     jqExpression: Option[String],
     name: Option[String],
-    pathAppend: Option[String]): ValidationNel[String, Option[Ingress]] = {
+    pathAppend: Option[String],
+    tlsSecrets: Seq[String]): ValidationNel[String, Option[Ingress]] = {
     annotations
       .appNameValidation
       .map { rawAppName =>
@@ -144,7 +145,9 @@ object Ingress {
                   .deepmerge(generateIngressAnnotations(ingressAnnotations))
                   .deepmerge(generateNamespaceAnnotation(annotations.namespace)),
                 "spec" -> Json(
-                  "rules" -> renderEndpoints(encodedEndpoints))),
+                  "rules" -> renderEndpoints(encodedEndpoints)).deepmerge(
+                    if (tlsSecrets.isEmpty) jEmptyObject else jObjectFields("tls" -> jArray(
+                      tlsSecrets.toList.map(s => jObjectFields("secretName" -> jString(s))))))),
               jqExpression))
       }
   }

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
@@ -53,51 +53,51 @@ object Job {
       |@| annotations.appNameValidation
       |@| annotations.versionValidation
       |@| restartPolicyValidation(restartPolicy)) { (applicationArgs, rawAppName, version, restartPolicy) =>
-      val appName = serviceName(rawAppName)
-      val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
+        val appName = serviceName(rawAppName)
+        val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
 
-      val labels = Map(
-        "appName" -> appName,
-        "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
+        val labels = Map(
+          "appName" -> appName,
+          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
 
-      val podTemplate =
-        PodTemplate.generate(
-          annotations,
-          apiVersion,
-          application,
-          imageName,
-          imagePullPolicy,
-          noOfReplicas,
-          if (restartPolicy == RestartPolicy.Default) RestartPolicy.OnFailure else restartPolicy,
-          externalServices,
-          deploymentType,
-          akkaClusterJoinExisting,
-          applicationArgs,
-          appName,
-          appNameVersion,
-          labels)
+        val podTemplate =
+          PodTemplate.generate(
+            annotations,
+            apiVersion,
+            application,
+            imageName,
+            imagePullPolicy,
+            noOfReplicas,
+            if (restartPolicy == RestartPolicy.Default) RestartPolicy.OnFailure else restartPolicy,
+            externalServices,
+            deploymentType,
+            akkaClusterJoinExisting,
+            applicationArgs,
+            appName,
+            appNameVersion,
+            labels)
 
-      val jobName =
-        deploymentType match {
-          case CanaryDeploymentType => appNameVersion
-          case BlueGreenDeploymentType => appNameVersion
-          case RollingDeploymentType => appName
-        }
+        val jobName =
+          deploymentType match {
+            case CanaryDeploymentType => appNameVersion
+            case BlueGreenDeploymentType => appNameVersion
+            case RollingDeploymentType => appName
+          }
 
-      Job(
-        jobName,
-        Json(
-          "apiVersion" -> apiVersion.asJson,
-          "kind" -> jString("Job"),
-          "metadata" -> Json(
-            "name" -> jobName.asJson,
-            "labels" -> labels.asJson)
-            .deepmerge(
-              annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> serviceName(ns).asJson))),
-          "spec" -> Json(
-            "template" -> podTemplate.json)),
-        jqExpression)
-    }
+        Job(
+          jobName,
+          Json(
+            "apiVersion" -> apiVersion.asJson,
+            "kind" -> jString("Job"),
+            "metadata" -> Json(
+              "name" -> jobName.asJson,
+              "labels" -> labels.asJson)
+              .deepmerge(
+                annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> serviceName(ns).asJson))),
+            "spec" -> Json(
+              "template" -> podTemplate.json)),
+          jqExpression)
+      }
 }
 
 /**

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -127,7 +127,8 @@ package object kubernetes extends LazyLogging {
         kubernetesArgs.ingressArgs.ingressAnnotations,
         kubernetesArgs.transformIngress,
         kubernetesArgs.ingressArgs.name,
-        kubernetesArgs.ingressArgs.pathAppend)
+        kubernetesArgs.ingressArgs.pathAppend,
+        kubernetesArgs.ingressArgs.tlsSecrets)
 
       val validateAkkaCluster =
         if (annotations.modules.contains(Module.AkkaClusterBootstrapping) && !generateDeploymentArgs.akkaClusterSkipValidation && kubernetesArgs.podControllerArgs.numberOfReplicas < AkkaClusterMinimumReplicas && !generateDeploymentArgs.akkaClusterJoinExisting && kubernetesArgs.generatePodControllers)

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argparse/InputArgsTest.scala
@@ -80,6 +80,8 @@ object InputArgsTest extends TestSuite {
                     "--ingress-annotation", "ing=123",
                     "--ingress-path-suffix", ".*",
                     "--ingress-api-version", "hello2",
+                    "--ingress-tls-secret", "hello1",
+                    "--ingress-tls-secret", "hello2",
                     "--env", "test1=test2",
                     "--output", "/tmp/foo",
                     "--registry-username", "john",
@@ -143,6 +145,7 @@ object InputArgsTest extends TestSuite {
                 assert(targetRuntimeArgs.ingressArgs.apiVersion.value.get.get == "hello2")
                 assert(targetRuntimeArgs.ingressArgs.ingressAnnotations == Map("ing" -> "123"))
                 assert(targetRuntimeArgs.ingressArgs.pathAppend == Some(".*"))
+                assert(targetRuntimeArgs.ingressArgs.tlsSecrets == Seq("hello1", "hello2"))
                 assert(targetRuntimeArgs.podControllerArgs.controllerType == PodControllerArgs.ControllerType.Job)
               }
             }

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
@@ -64,7 +64,8 @@ object IngressJsonTest extends TestSuite {
           ingressAnnotations = Map.empty,
           None,
           None,
-          pathAppend = Option.empty).toOption.get
+          pathAppend = None,
+          tlsSecrets = Seq.empty).toOption.get
         val expectedJson =
           """
             |{
@@ -153,7 +154,8 @@ object IngressJsonTest extends TestSuite {
           ingressAnnotations = Map("kubernetes.io/ingress.class" -> "istio"),
           None,
           None,
-          pathAppend = Some("/.*")).toOption.get
+          pathAppend = Some("/.*"),
+          tlsSecrets = Seq("hello1", "hello2")).toOption.get
 
         val expectedJson =
           """
@@ -168,6 +170,10 @@ object IngressJsonTest extends TestSuite {
             |    "namespace": "chirper"
             |  },
             |  "spec" : {
+            |    "tls": [
+            |      { "secretName": "hello1" },
+            |      { "secretName": "hello2" }
+            |    ],
             |    "rules" : [
             |      {
             |        "host" : "test.com",
@@ -205,12 +211,12 @@ object IngressJsonTest extends TestSuite {
       }
 
       "should fail if application name is not defined" - {
-        assert(Ingress.generate(annotations.copy(appName = None), "extensions/v1beta1", None, Map.empty, None, None, Option.empty).toOption.isEmpty)
+        assert(Ingress.generate(annotations.copy(appName = None), "extensions/v1beta1", None, Map.empty, None, None, None, Seq.empty).toOption.isEmpty)
       }
 
       "jq" - {
         Ingress
-          .generate(annotations.copy(appName = Some("test")), "extensions/v1beta1", None, Map.empty, Some(".jqTest = \"test\""), None, Option.empty)
+          .generate(annotations.copy(appName = Some("test")), "extensions/v1beta1", None, Map.empty, Some(".jqTest = \"test\""), None, None, Seq.empty)
           .toOption
           .get
           .get
@@ -226,7 +232,8 @@ object IngressJsonTest extends TestSuite {
           ingressAnnotations = Map("kubernetes.io/ingress.class" -> "istio"),
           None,
           None,
-          None).toOption.get.get
+          None,
+          Seq.empty).toOption.get.get
 
         val b = Ingress.generate(
           createAnnotations("enemyservice", "/ac/other/path", "/ab/other/path"),
@@ -235,7 +242,8 @@ object IngressJsonTest extends TestSuite {
           ingressAnnotations = Map("kubernetes.io/ingress.class" -> "istio2"),
           None,
           None,
-          None).toOption.get.get
+          None,
+          Seq.empty).toOption.get.get
 
         val expectedJson =
           """


### PR DESCRIPTION
Per https://kubernetes.io/docs/concepts/services-networking/ingress/#tls

example usage:

```bash
$ rp generate-kubernetes-resources gcr.io/platform-tooling/friend-impl:1.0.0-SNAPSHOT --generate-ingress --ingress-tls-secret testone --ingress-tls-secret test2
---
apiVersion: "extensions/v1beta1"
kind: Ingress
metadata:
  name: friendservice
spec:
  rules:
    - http:
        paths:
          - path: "/api/users"
            backend:
              serviceName: friendservice
              servicePort: 10000
  tls:
    - secretName: testone
    - secretName: test2
-> 0

```