### PR TITLE
Now strips protocol from registry realm for authentication credentials

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/package.scala
@@ -22,14 +22,18 @@ package object docker {
   val DockerDefaultLibrary = "library"
   val DockerDefaultTag = "latest"
 
-  // Sometimes authentication credentials store different address than our default server,
-  // this function handles these discrepancies.
+  /**
+   * Normalizes authentication realms and determines if they match a supplied registry.
+   */
   def registryAuthNameMatches(registry: String, authRealm: String): Boolean = {
-    if (registry == authRealm)
-      true
-    else if (registry == DockerDefaultRegistry && authRealm == "https://index.docker.io/v1/")
-      true
-    else
-      false
+    val protocol = "https://"
+
+    val authRealmToTest =
+      if (authRealm.startsWith(protocol))
+        authRealm.drop(protocol.length)
+      else
+        authRealm
+
+    registry == authRealmToTest || (registry == DockerDefaultRegistry && authRealmToTest == "index.docker.io/v1/")
   }
 }

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerPackageTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.docker
+
+import utest._
+
+object DockerPackageTest extends TestSuite {
+  val tests = this {
+    "exact match" - {
+      assert(registryAuthNameMatches("test.registry.com", "test.registry.com"))
+    }
+
+    "DockerHub overwrite" - {
+      assert(registryAuthNameMatches("registry.hub.docker.com", "https://index.docker.io/v1/"))
+      assert(registryAuthNameMatches("registry.hub.docker.com", "index.docker.io/v1/"))
+    }
+
+    "https match" - {
+      assert(registryAuthNameMatches("test.registry.com", "https://test.registry.com"))
+    }
+
+    "not matching" - {
+      assert(!registryAuthNameMatches("test.registry.info", "test.registry.com"))
+      assert(!registryAuthNameMatches("test2.registry.info", "test.registry.info"))
+    }
+  }
+}


### PR DESCRIPTION
Credentials may have the protocol (`https`) in the realm, so we now strip this away when determining if a set of credentials apply for a given registry.