### PR TITLE
Fix error messages with multiple docker images

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -192,7 +192,7 @@ object Main extends LazyLogging {
                 val outputHandler = kubernetes.handleGeneratedResources(kubernetesArgs.output)
 
                 def configFailure(img: String, t: Throwable) =
-                  s"Failed to obtain Docker config for ${generateDeploymentArgs.dockerImages.mkString(", ")}, ${t.getMessage}"
+                  s"Failed to obtain Docker config for $img, ${t.getMessage}"
 
                 val output =
                   Future


### PR DESCRIPTION
This happens now when multiple docker images are passed in, one found and one missing:
```
rp generate-kubernetes-resources --generate-all "fakeimage:latest" "realimage:latest"
[error, com.lightbend.rp.reactivecli.Main$] Failed to obtain Docker config for fakeimage:latest, realimage:latest, image doesn't seem to exist in docker registry
```

This PR fixes that so that only thing printed is:
```
[error, com.lightbend.rp.reactivecli.Main$] Failed to obtain Docker config for fakeimage:latest, image doesn't seem to exist in docker registry
```

When multiple images are missing, one error is printed for each.

I'm still not sure why it only printed one message previously, I was expecting the same message repeated. Maybe `NonEmptyList(failureMessages.head, failureMessages.tail: _*)` removes duplicate items?
