### PR TITLE
Now supports digest syntax for docker registries

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
@@ -97,9 +97,9 @@ object DockerRegistry extends LazyLogging {
     } yield (
       r._1.statusCode match {
         case x if x >= 200 && x <= 299 => Right(())
-        case 404 => Left("Unable to find repository or registry")
-        case 401 => Left("Unable to access repository or registry; check authentication")
-        case c => Left(s"Unable to find repository or registry [$c]")
+        case 404 => Left("unable to find repository or registry")
+        case 401 => Left("unable to access repository or registry; check authentication")
+        case c => Left(s"unable to find repository or registry [$c]")
       },
       r._2)
 
@@ -112,8 +112,8 @@ object DockerRegistry extends LazyLogging {
         case Right(_) => Future.successful(())
       }
       failureMessages = Map(
-        404L -> s"Unable to find image with ${img.ref.name} ${img.ref.value}",
-        401L -> "Unable to access image; check authentication")
+        404L -> s"unable to find image with ${img.ref.name} ${img.ref.value}",
+        401L -> "unable to access image; check authentication")
       manifest <- getManifest(http, credentials, useHttps, validateTls)(img, token = validRepository._2, failureMessages)
       blob <- getBlob(http, credentials, useHttps, validateTls)(img, manifest._1.config.digest, token = validRepository._2)
       config <- Future.fromTry(getDecoded[Config](blob._1, Map.empty))
@@ -140,7 +140,7 @@ object DockerRegistry extends LazyLogging {
         new IllegalArgumentException(
           failureMessages.getOrElse(
             response.statusCode,
-            s"Expected code 200, received ${response.statusCode}")))
+            s"expected code 200, received ${response.statusCode}")))
 
   private def getWithAuth(http: HttpExchange, auth: Option[HttpRequest.Auth], validateTls: Boolean, url: String, headers: HttpHeaders, overrideToken: Option[HttpRequest.BearerToken], fallbackScope: Option[String]): Future[(HttpResponse, Option[HttpRequest.BearerToken])] = {
     auth match {

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
@@ -33,7 +33,7 @@ object DockerRegistry extends LazyLogging {
     encodeURI(s"${protocol(useHttps)}://${img.url}/v2/${img.namespace}/${img.image}/blobs/$digest")
 
   private[docker] def manifestUrl(img: Image, useHttps: Boolean): String =
-    encodeURI(s"${protocol(useHttps)}://${img.url}/v2/${img.namespace}/${img.image}/manifests/${img.tag}")
+    encodeURI(s"${protocol(useHttps)}://${img.url}/v2/${img.namespace}/${img.image}/manifests/${img.ref.value}")
 
   private[docker] def tagsUrl(img: Image, useHttps: Boolean): String =
     encodeURI(s"${protocol(useHttps)}://${img.url}/v2/${img.namespace}/${img.image}/tags/list")
@@ -52,16 +52,23 @@ object DockerRegistry extends LazyLogging {
     val providedNs = (parts.length > 2).option(parts(1))
       .orElse((parts.length > 1).option(parts(0)))
 
-    val imageParts = (parts.length > 2).option(parts(2))
+    val imageWithTagOrDigest = (parts.length > 2).option(parts(2))
       .orElse((parts.length > 1).option(parts(1)))
       .getOrElse(parts(0))
-      .split(":", 2)
 
-    val image = imageParts(0)
+    val firstColon = imageWithTagOrDigest.indexOf(":")
 
-    val providedTag = (imageParts.length > 1).option(imageParts(1))
+    val firstAt = imageWithTagOrDigest.indexOf("@")
 
-    if (image.isEmpty || providedTag.fold(false)(_.isEmpty))
+    val (image, providedRef) =
+      if (firstColon >= 0 && firstAt >= 0)
+        imageWithTagOrDigest.take(firstAt) -> Some(ImageDigest(imageWithTagOrDigest.substring(firstAt + 1)))
+      else if (firstColon >= 0)
+        imageWithTagOrDigest.take(firstColon) -> Some(ImageTag(imageWithTagOrDigest.substring(firstColon + 1)))
+      else
+        imageWithTagOrDigest -> None
+
+    if (image.isEmpty || providedRef.fold(false)(_.value.isEmpty))
       Failure(new IllegalArgumentException(s"""Cannot parse uri "$uri"""))
     else
       Success(
@@ -69,11 +76,11 @@ object DockerRegistry extends LazyLogging {
           url = providedUrl.getOrElse(DockerDefaultRegistry),
           namespace = providedNs.getOrElse(DockerDefaultLibrary),
           image = image,
-          tag = providedTag.getOrElse(DockerDefaultTag),
+          ref = providedRef.getOrElse(ImageTag(DockerDefaultTag)),
           providedUrl = providedUrl,
           providedNamespace = providedNs,
           providedImage = image,
-          providedTag = providedTag))
+          providedRef = providedRef))
   }
 
   private def getBlob(http: HttpExchange, credentials: Option[HttpRequest.Auth], useHttps: Boolean, validateTls: Boolean)(img: Image, digest: String, token: Option[HttpRequest.BearerToken]): Future[(HttpResponse, Option[HttpRequest.BearerToken])] =
@@ -81,35 +88,35 @@ object DockerRegistry extends LazyLogging {
       r <- getWithAuth(http, credentials, validateTls, blobUrl(img, digest, useHttps), HttpHeaders(Map.empty), token, Some(img.pullScope))
     } yield r
 
-  private def getTags(http: HttpExchange, credentials: Option[HttpRequest.Auth], useHttps: Boolean, validateTls: Boolean)(img: Image, token: Option[HttpRequest.BearerToken])(implicit settings: HttpSettings): Future[(Option[String], Option[HttpRequest.BearerToken])] =
+  private def checkRepositoryValid(http: HttpExchange, credentials: Option[HttpRequest.Auth], useHttps: Boolean, validateTls: Boolean)(img: Image, token: Option[HttpRequest.BearerToken])(implicit settings: HttpSettings): Future[(Either[String, Unit], Option[HttpRequest.BearerToken])] =
     for {
-      r <- getWithAuth(http, credentials, validateTls, tagsUrl(img, useHttps), HttpHeaders(Map()), token, Some(img.pullScope))
-    } yield r._1.body -> r._2
+      // We only fetch a single tag (?n=1) because we only care about status codes, and this saves data transfer for
+      // large repositories.
 
-  private def imgValid(tags: Option[String], img: Image): Try[Boolean] = {
-    tags match {
-      case None =>
-        Failure(new IllegalArgumentException(s"got unexpected docker registry response"))
-      case Some(str) =>
-        val tags = Parse.parseOption(str).flatMap(_.hcursor.downField("tags").focus)
-        val foundTag = tags.flatMap(j =>
-          j.hcursor.downArray.find(tag => tag.isString && tag.string == Some(img.tag)).focus)
-        (tags, foundTag) match {
-          case (None, None) => Failure(new IllegalArgumentException(s"image doesn't seem to exist in docker registry"))
-          case (Some(_), None) => Failure(new IllegalArgumentException(s"image ${img.image} doesn't have tag named ${img.tag}"))
-          case _ => Success(true)
-        }
-    }
-  }
+      r <- getWithAuth(http, credentials, validateTls, s"${tagsUrl(img, useHttps)}?n=1", HttpHeaders(Map()), token, Some(img.pullScope))
+    } yield (
+      r._1.statusCode match {
+        case x if x >= 200 && x <= 299 => Right(())
+        case 404 => Left("Unable to find repository or registry")
+        case 401 => Left("Unable to access repository or registry; check authentication")
+        case c => Left(s"Unable to find repository or registry [$c]")
+      },
+      r._2)
 
   def getConfig(http: HttpExchange, credentials: Option[HttpRequest.Auth], useHttps: Boolean, validateTls: Boolean)(uri: String, token: Option[HttpRequest.BearerToken])(implicit settings: HttpSettings): Future[(Config, Option[HttpRequest.BearerToken])] =
     for {
       img <- Future.fromTry(parseImageUri(uri))
-      tags <- getTags(http, credentials, useHttps, validateTls)(img, token)
-      valid <- Future.fromTry(imgValid(tags._1, img))
-      manifest <- getManifest(http, credentials, useHttps, validateTls)(img, token = tags._2)
-      blob <- getBlob(http, credentials, useHttps, validateTls)(img, manifest._1.config.digest, token = tags._2)
-      config <- Future.fromTry(getDecoded[Config](blob._1))
+      validRepository <- checkRepositoryValid(http, credentials, useHttps, validateTls)(img, token)
+      _ <- validRepository._1 match {
+        case Left(errorMessage) => Future.failed(new IllegalArgumentException(errorMessage))
+        case Right(_) => Future.successful(())
+      }
+      failureMessages = Map(
+        404L -> s"Unable to find image with ${img.ref.name} ${img.ref.value}",
+        401L -> "Unable to access image; check authentication")
+      manifest <- getManifest(http, credentials, useHttps, validateTls)(img, token = validRepository._2, failureMessages)
+      blob <- getBlob(http, credentials, useHttps, validateTls)(img, manifest._1.config.digest, token = validRepository._2)
+      config <- Future.fromTry(getDecoded[Config](blob._1, Map.empty))
     } yield config -> blob._2
 
   def getRegistry(image: String): Option[String] =
@@ -117,19 +124,23 @@ object DockerRegistry extends LazyLogging {
       .toOption
       .map(_.url)
 
-  private def getManifest(http: HttpExchange, credentials: Option[HttpRequest.Auth], useHttps: Boolean, validateTls: Boolean)(img: Image, token: Option[HttpRequest.BearerToken]): Future[(Manifest, Option[HttpRequest.BearerToken])] =
+  private def getManifest(http: HttpExchange, credentials: Option[HttpRequest.Auth], useHttps: Boolean, validateTls: Boolean)(img: Image, token: Option[HttpRequest.BearerToken], failureMessages: Map[Long, String]): Future[(Manifest, Option[HttpRequest.BearerToken])] =
     for {
       r <- getWithAuth(http, credentials, validateTls, manifestUrl(img, useHttps), HttpHeaders(Map("Accept" -> DockerAcceptManifestHeader)), token, Some(img.pullScope))
-      v <- Future.fromTry(getDecoded[Manifest](r._1))
+      v <- Future.fromTry(getDecoded[Manifest](r._1, failureMessages))
     } yield v -> r._2
 
-  private def getDecoded[T](response: HttpResponse)(implicit decode: DecodeJson[T]): Try[T] =
-    if (response.statusCode == 200)
+  private def getDecoded[T](response: HttpResponse, failureMessages: Map[Long, String])(implicit decode: DecodeJson[T]): Try[T] =
+    if (response.statusCode == 200L)
       response.body.getOrElse("").decodeEither[T].fold(
         err => Failure(new IllegalArgumentException(s"Decode Failure: $err")),
         Success.apply)
     else
-      Failure(new IllegalArgumentException(s"Expected code 200, received ${response.statusCode}"))
+      Failure(
+        new IllegalArgumentException(
+          failureMessages.getOrElse(
+            response.statusCode,
+            s"Expected code 200, received ${response.statusCode}")))
 
   private def getWithAuth(http: HttpExchange, auth: Option[HttpRequest.Auth], validateTls: Boolean, url: String, headers: HttpHeaders, overrideToken: Option[HttpRequest.BearerToken], fallbackScope: Option[String]): Future[(HttpResponse, Option[HttpRequest.BearerToken])] = {
     auth match {

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/Image.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/Image.scala
@@ -16,15 +16,27 @@
 
 package com.lightbend.rp.reactivecli.docker
 
+sealed trait ImageRef {
+  def name: String
+  def value: String
+}
+
+case class ImageDigest(value: String) extends ImageRef {
+  def name: String = "digest"
+}
+
+case class ImageTag(value: String) extends ImageRef {
+  def name: String = "tag"
+}
+
 case class Image(
   url: String,
   namespace: String,
   image: String,
-  tag: String,
+  ref: ImageRef,
   providedUrl: Option[String],
   providedNamespace: Option[String],
   providedImage: String,
-  providedTag: Option[String]) {
-
+  providedRef: Option[ImageRef]) {
   def pullScope: String = s"repository:$namespace/$image:pull"
 }

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerPackageTest.scala
@@ -19,7 +19,7 @@ package com.lightbend.rp.reactivecli.docker
 import utest._
 
 object DockerPackageTest extends TestSuite {
-  val tests = this {
+  val tests = this{
     "exact match" - {
       assert(registryAuthNameMatches("test.registry.com", "test.registry.com"))
     }

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
@@ -29,11 +29,11 @@ object DockerRegistryTest extends TestSuite {
               DockerDefaultRegistry,
               DockerDefaultLibrary,
               "alpine",
-              "3.5",
+              ImageTag("3.5"),
               None,
               None,
               "alpine",
-              Some("3.5")), "abc123", useHttps = true) == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/blobs/abc123")
+              Some(ImageTag("3.5"))), "abc123", useHttps = true) == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/blobs/abc123")
       }
 
       "with http" - {
@@ -43,11 +43,11 @@ object DockerRegistryTest extends TestSuite {
               DockerDefaultRegistry,
               DockerDefaultLibrary,
               "alpine",
-              "3.5",
+              ImageTag("3.5"),
               None,
               None,
               "alpine",
-              Some("3.5")), "abc123", useHttps = false) == s"http://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/blobs/abc123")
+              Some(ImageTag("3.5"))), "abc123", useHttps = false) == s"http://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/blobs/abc123")
       }
     }
 
@@ -59,11 +59,11 @@ object DockerRegistryTest extends TestSuite {
               DockerDefaultRegistry,
               DockerDefaultLibrary,
               "alpine",
-              "3.5",
+              ImageTag("3.5"),
               None,
               None,
               "alpine",
-              Some("3.5")), useHttps = true) == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/manifests/3.5")
+              Some(ImageTag("3.5"))), useHttps = true) == s"https://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/manifests/3.5")
       }
 
       "with http" - {
@@ -73,11 +73,11 @@ object DockerRegistryTest extends TestSuite {
               DockerDefaultRegistry,
               DockerDefaultLibrary,
               "alpine",
-              "3.5",
+              ImageTag("3.5"),
               None,
               None,
               "alpine",
-              Some("3.5")), useHttps = false) == s"http://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/manifests/3.5")
+              Some(ImageTag("3.5"))), useHttps = false) == s"http://$DockerDefaultRegistry/v2/$DockerDefaultLibrary/alpine/manifests/3.5")
       }
     }
 
@@ -89,7 +89,7 @@ object DockerRegistryTest extends TestSuite {
               DockerDefaultRegistry,
               DockerDefaultLibrary,
               "alpine",
-              "latest",
+              ImageTag("latest"),
               None,
               None,
               "alpine",
@@ -102,11 +102,11 @@ object DockerRegistryTest extends TestSuite {
               DockerDefaultRegistry,
               DockerDefaultLibrary,
               "alpine",
-              "3.5",
+              ImageTag("3.5"),
               None,
               None,
               "alpine",
-              Some("3.5"))))
+              Some(ImageTag("3.5")))))
 
       assert(
         DockerRegistry.parseImageUri("lightbend-docker.registry.bintray.io/conductr/oci-in-docker") ==
@@ -115,7 +115,7 @@ object DockerRegistryTest extends TestSuite {
               "lightbend-docker.registry.bintray.io",
               "conductr",
               "oci-in-docker",
-              "latest",
+              ImageTag("latest"),
               Some("lightbend-docker.registry.bintray.io"),
               Some("conductr"),
               "oci-in-docker",
@@ -128,11 +128,24 @@ object DockerRegistryTest extends TestSuite {
               "lightbend-docker.registry.bintray.io",
               "conductr",
               "oci-in-docker",
-              "0.1",
+              ImageTag("0.1"),
               Some("lightbend-docker.registry.bintray.io"),
               Some("conductr"),
               "oci-in-docker",
-              Some("0.1"))))
+              Some(ImageTag("0.1")))))
+
+      assert(
+        DockerRegistry.parseImageUri("lightbend-docker.registry.bintray.io/conductr/oci-in-docker@sha256:asdfdfasaw123") ==
+          Success(
+            Image(
+              "lightbend-docker.registry.bintray.io",
+              "conductr",
+              "oci-in-docker",
+              ImageDigest("sha256:asdfdfasaw123"),
+              Some("lightbend-docker.registry.bintray.io"),
+              Some("conductr"),
+              "oci-in-docker",
+              Some(ImageDigest("sha256:asdfdfasaw123")))))
 
       assert(DockerRegistry.parseImageUri("").isFailure)
       assert(DockerRegistry.parseImageUri("test:").isFailure)


### PR DESCRIPTION
Fixes #122

This modifies the Docker Registry API support to support digest syntax, e.g. `rp generate-kubernetes-resources gcr.io/whatever/my-image@sha256:020c5981ef9e104d92ddd2f84945d4d4a2f9a887bac0e2a8762c8966e9d97d81`

I had to touch a fair bit of the validation code to implement this, as it's conceivable that the repository exists without any tags. Therefore, we still check the same tags input, but are only concerned with its status code. We know that if tags returns 200, but we get a 404 later, that we were given an invalid tag or digest.

### Digest Works

```bash
$ rp generate-kubernetes-resources  \
  --generate-pod-controllers \
  --pod-controller-replicas 2 \
lightbend-docker-registry.bintray.io/test/akka-cluster-tooling-example@sha256:28dd942527fc3cf4ea1579cd37d228a2a7138d33d79124e3262c897f54f76e1f
---
apiVersion: "apps/v1beta2"
kind: Deployment
metadata:
  name: "akka-cluster-tooling-example-v0-1-0"
  labels:
    appName: "akka-cluster-tooling-example"
    appNameVersion: "akka-cluster-tooling-example-v0-1-0"
spec:
  replicas: 2
  selector:
    matchLabels:
      appNameVersion: "akka-cluster-tooling-example-v0-1-0"
  template:
    metadata:
      labels:
        appName: "akka-cluster-tooling-example"
        appNameVersion: "akka-cluster-tooling-example-v0-1-0"
    spec:
      restartPolicy: Always
      containers:
        - name: "akka-cluster-tooling-example"
          image: "lightbend-docker-registry.bintray.io/test/akka-cluster-tooling-example@sha256:28dd942527fc3cf4ea1579cd37d228a2a7138d33d79124e3262c897f54f76e1f"
          imagePullPolicy: IfNotPresent
          env:
            - name: "RP_APP_NAME"
              value: "akka-cluster-tooling-example"
            - name: "RP_APP_TYPE"
              value: basic
            - name: "RP_APP_VERSION"
              value: "0.1.0"
            - name: "RP_ENDPOINTS"
              value: "AKKA_REMOTE,AKKA_MGMT_HTTP,HTTP"
            - name: "RP_ENDPOINTS_COUNT"
              value: "3"
            - name: "RP_ENDPOINT_0_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_0_BIND_PORT"
              value: "10000"
            - name: "RP_ENDPOINT_0_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_0_PORT"
              value: "10000"
            - name: "RP_ENDPOINT_1_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_1_BIND_PORT"
              value: "10001"
            - name: "RP_ENDPOINT_1_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_1_PORT"
              value: "10001"
            - name: "RP_ENDPOINT_2_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_2_BIND_PORT"
              value: "10002"
            - name: "RP_ENDPOINT_2_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_2_PORT"
              value: "10002"
            - name: "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT"
              value: "10001"
            - name: "RP_ENDPOINT_AKKA_MGMT_HTTP_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_AKKA_MGMT_HTTP_PORT"
              value: "10001"
            - name: "RP_ENDPOINT_AKKA_REMOTE_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_AKKA_REMOTE_BIND_PORT"
              value: "10000"
            - name: "RP_ENDPOINT_AKKA_REMOTE_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_AKKA_REMOTE_PORT"
              value: "10000"
            - name: "RP_ENDPOINT_HTTP_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_HTTP_BIND_PORT"
              value: "10002"
            - name: "RP_ENDPOINT_HTTP_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_HTTP_PORT"
              value: "10002"
            - name: "RP_JAVA_OPTS"
              value: "-Dconfig.resource=rp-application.conf -Dakka.discovery.method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=akka-cluster-tooling-example -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=2 -Dakka.discovery.kubernetes-api.pod-label-selector=appName=%s"
            - name: "RP_KUBERNETES_POD_IP"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_KUBERNETES_POD_NAME"
              valueFrom:
                fieldRef:
                  fieldPath: "metadata.name"
            - name: "RP_MODULES"
              value: "akka-cluster-bootstrapping,akka-management,common,service-discovery,status"
            - name: "RP_PLATFORM"
              value: kubernetes
          ports:
            - containerPort: 10000
              name: "akka-remote"
            - containerPort: 10001
              name: "akka-mgmt-http"
            - containerPort: 10002
              name: http
          volumeMounts: []
          command:
            - "/rp-start"
          args:
            - "bin/akka-cluster-tooling-example"
          readinessProbe:
            httpGet:
              path: "/platform-tooling/ready"
              port: "akka-mgmt-http"
            periodSeconds: 10
          livenessProbe:
            httpGet:
              path: "/platform-tooling/healthy"
              port: "akka-mgmt-http"
            periodSeconds: 10
            initialDelaySeconds: 60
      volumes: []
-> 0

### Tags still work

```bash
$ rp generate-kubernetes-resources  \
  --generate-pod-controllers \
  --pod-controller-replicas 2 \
lightbend-docker-registry.bintray.io/test/akka-cluster-tooling-example:0.1.0
---
apiVersion: "apps/v1beta2"
kind: Deployment
metadata:
  name: "akka-cluster-tooling-example-v0-1-0"
  labels:
    appName: "akka-cluster-tooling-example"
    appNameVersion: "akka-cluster-tooling-example-v0-1-0"
spec:
  replicas: 2
  selector:
    matchLabels:
      appNameVersion: "akka-cluster-tooling-example-v0-1-0"
  template:
    metadata:
      labels:
        appName: "akka-cluster-tooling-example"
        appNameVersion: "akka-cluster-tooling-example-v0-1-0"
    spec:
      restartPolicy: Always
      containers:
        - name: "akka-cluster-tooling-example"
          image: "lightbend-docker-registry.bintray.io/test/akka-cluster-tooling-example:0.1.0"
          imagePullPolicy: IfNotPresent
          env:
            - name: "RP_APP_NAME"
              value: "akka-cluster-tooling-example"
            - name: "RP_APP_TYPE"
              value: basic
            - name: "RP_APP_VERSION"
              value: "0.1.0"
            - name: "RP_ENDPOINTS"
              value: "AKKA_REMOTE,AKKA_MGMT_HTTP,HTTP"
            - name: "RP_ENDPOINTS_COUNT"
              value: "3"
            - name: "RP_ENDPOINT_0_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_0_BIND_PORT"
              value: "10000"
            - name: "RP_ENDPOINT_0_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_0_PORT"
              value: "10000"
            - name: "RP_ENDPOINT_1_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_1_BIND_PORT"
              value: "10001"
            - name: "RP_ENDPOINT_1_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_1_PORT"
              value: "10001"
            - name: "RP_ENDPOINT_2_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_2_BIND_PORT"
              value: "10002"
            - name: "RP_ENDPOINT_2_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_2_PORT"
              value: "10002"
            - name: "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_AKKA_MGMT_HTTP_BIND_PORT"
              value: "10001"
            - name: "RP_ENDPOINT_AKKA_MGMT_HTTP_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_AKKA_MGMT_HTTP_PORT"
              value: "10001"
            - name: "RP_ENDPOINT_AKKA_REMOTE_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_AKKA_REMOTE_BIND_PORT"
              value: "10000"
            - name: "RP_ENDPOINT_AKKA_REMOTE_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_AKKA_REMOTE_PORT"
              value: "10000"
            - name: "RP_ENDPOINT_HTTP_BIND_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_HTTP_BIND_PORT"
              value: "10002"
            - name: "RP_ENDPOINT_HTTP_HOST"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_ENDPOINT_HTTP_PORT"
              value: "10002"
            - name: "RP_JAVA_OPTS"
              value: "-Dconfig.resource=rp-application.conf -Dakka.discovery.method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=akka-cluster-tooling-example -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=2 -Dakka.discovery.kubernetes-api.pod-label-selector=appName=%s"
            - name: "RP_KUBERNETES_POD_IP"
              valueFrom:
                fieldRef:
                  fieldPath: "status.podIP"
            - name: "RP_KUBERNETES_POD_NAME"
              valueFrom:
                fieldRef:
                  fieldPath: "metadata.name"
            - name: "RP_MODULES"
              value: "akka-cluster-bootstrapping,akka-management,common,service-discovery,status"
            - name: "RP_PLATFORM"
              value: kubernetes
          ports:
            - containerPort: 10000
              name: "akka-remote"
            - containerPort: 10001
              name: "akka-mgmt-http"
            - containerPort: 10002
              name: http
          volumeMounts: []
          command:
            - "/rp-start"
          args:
            - "bin/akka-cluster-tooling-example"
          readinessProbe:
            httpGet:
              path: "/platform-tooling/ready"
              port: "akka-mgmt-http"
            periodSeconds: 10
          livenessProbe:
            httpGet:
              path: "/platform-tooling/healthy"
              port: "akka-mgmt-http"
            periodSeconds: 10
            initialDelaySeconds: 60
      volumes: []
-> 0
```

### Example Failures


```bash
~/work/lightbend/akka-cluster-tooling-example#master $ rp generate-kubernetes-resources  --generate-pod-controllers --pod-controller-replicas 2 lightbend-docker-registry.bintray.io/test/afkka-cluster-tooling-example:hello
[error, com.lightbend.rp.reactivecli.Main$] Failed to obtain Docker config for lightbend-docker-registry.bintray.io/test/afkka-cluster-tooling-example:hello, Unable to find repository or registry
-> 1

~/work/lightbend/akka-cluster-tooling-example#master $ rp generate-kubernetes-resources  --generate-pod-controllers --pod-controller-replicas 2 lightbend-docker-registry.bintray.io/test/akka-cluster-tooling-example:hello
[error, com.lightbend.rp.reactivecli.Main$] Failed to obtain Docker config for lightbend-docker-registry.bintray.io/test/akka-cluster-tooling-example:hello, Unable to find image with tag hello
-> 1

~/work/lightbend/akka-cluster-tooling-example#master $ rp generate-kubernetes-resources  --generate-pod-controllers --pod-controller-replicas 2 lightbend-docker-registry.bintray.io/test/akka-cluster-tooling-example@sha256:asdf
[error, com.lightbend.rp.reactivecli.Main$] Failed to obtain Docker config for lightbend-docker-registry.bintray.io/test/akka-cluster-tooling-example@sha256:asdf, Unable to find image with digest sha256:asdf
-> 1
```
