### PR TITLE
Source RP_NAMESPACE using Kubernetes ref spec

### DIFF
--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -150,6 +150,10 @@ object DeploymentJsonTest extends TestSuite {
               |              "value": "-Dakka.cluster.bootstrap.contact-point-discovery.discovery-method=akka.discovery.reactive-lib-kubernetes -Dconfig.resource=my-config.conf -Dakka.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1"
               |            },
               |            {
+              |              "name": "RP_DYN_JAVA_OPTS",
+              |              "value": "-Dakka.discovery.kubernetes-api.pod-namespace=chirper"
+              |            },
+              |            {
               |              "name": "RP_ENDPOINTS",
               |              "value": "EP1,EP2,EP3"
               |            },
@@ -319,7 +323,11 @@ object DeploymentJsonTest extends TestSuite {
               |            },
               |            {
               |              "name": "RP_NAMESPACE",
-              |              "value": "chirper"
+              |              "valueFrom": {
+              |                "fieldRef": {
+              |                  "fieldPath": "metadata.namespace"
+              |                }
+              |              }
               |            },
               |            {
               |              "name": "RP_PLATFORM",
@@ -628,21 +636,6 @@ object DeploymentJsonTest extends TestSuite {
     }
 
     "RP environment variables" - {
-      "namespace" - {
-        "when present" - {
-          val result = RpEnvironmentVariables.namespaceEnv(Some("ns"))
-          val expectedResult = Map(
-            "RP_NAMESPACE" -> LiteralEnvironmentVariable("ns"))
-          assert(result == expectedResult)
-        }
-
-        "when not present" - {
-          val result = RpEnvironmentVariables.namespaceEnv(None)
-          assert(result.isEmpty)
-
-        }
-      }
-
       "app name" - {
         "when present" - {
           val result = RpEnvironmentVariables.appNameEnvs(Some("app"))

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
@@ -91,6 +91,7 @@ object JobJsonTest extends TestSuite {
                     jObjectFields("name" -> jString("RP_ENDPOINTS_COUNT"), "value" -> jString("0")),
                     jObjectFields("name" -> jString("RP_KUBERNETES_POD_IP"), "valueFrom" -> jObjectFields("fieldRef" -> jObjectFields("fieldPath" -> jString("status.podIP")))),
                     jObjectFields("name" -> jString("RP_KUBERNETES_POD_NAME"), "valueFrom" -> jObjectFields("fieldRef" -> jObjectFields("fieldPath" -> jString("metadata.name")))),
+                    jObjectFields("name" -> jString("RP_NAMESPACE"), "valueFrom" -> jObjectFields("fieldRef" -> jObjectFields("fieldPath" -> jString("metadata.namespace")))),
                     jObjectFields("name" -> jString("RP_PLATFORM"), "value" -> jString("kubernetes"))))),
               "volumes" -> jEmptyArray))))
 


### PR DESCRIPTION
We now set `RP_NAMESPACE` to the field ref `metadata.namespace`. This allows our resources to work even if users to specify namespace via `kubectl`.

I decided we don't need to remove the `--namespace` flag, it's still compatible with this approach and provides some flexibility.

`RP_NAMESPACE` was chosen / remains the env var name as we reference that value in `reactive-lib`.

Fixes #124