### PR TITLE
Fix bug with yaml renderer and strings 'true', 'false', 'null'

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argonaut/YamlRenderer.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argonaut/YamlRenderer.scala
@@ -104,6 +104,9 @@ object YamlRenderer {
 
   private def spaces(level: Int): String = Indent * level
 
-  private def needsQuotes(string: String) =
-    string.isEmpty || string.trim != string || !string.matches("^[A-Za-z][A-Za-z0-9 ]*$")
+  private def needsQuotes(string: String) = {
+    val alwaysQuote = Set("null", "true", "false")
+
+    string.isEmpty || string.trim != string || !string.matches("^[A-Za-z][A-Za-z0-9 ]*$") || alwaysQuote.contains(string.toLowerCase)
+  }
 }

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argonaut/YamlRendererTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/argonaut/YamlRendererTest.scala
@@ -42,6 +42,16 @@ object YamlRendererTest extends TestSuite {
 
       "false" - equal(render(jFalse), "false")
 
+      "true string" - equal(render(jString("true")), "\"true\"")
+
+      "True string" - equal(render(jString("True")), "\"True\"")
+
+      "false string" - equal(render(jString("false")), "\"false\"")
+
+      "False string" - equal(render(jString("False")), "\"False\"")
+
+      "null string" - equal(render(jString("null")), "\"null\"")
+
       "numeric arrays" - equal(
         render(jArrayElements(jNumber(1), jNumber(2), jNumber(3))),
 


### PR DESCRIPTION
We should have been quoting and escaping `true`, `false`, `null` but we weren't. Now we are.