### PR TITLE
Remove discovery-related labels if join existing cluster is specified

### DIFF
--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
@@ -73,7 +73,6 @@ object JobJsonTest extends TestSuite {
           "template" -> jObjectFields(
             "metadata" -> jObjectFields(
               "labels" -> jObjectFields(
-                "appName" -> jString("friendimpl"),
                 "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"))),
             "spec" -> jObjectFields(
               "restartPolicy" -> jString("OnFailure"),
@@ -113,7 +112,7 @@ object JobJsonTest extends TestSuite {
           None,
           true)
 
-      assert(job.toOption.isDefined == false)
+      assert(!job.toOption.isDefined)
     }
   }
 }


### PR DESCRIPTION
Fixes #128 - if a user provides `--akka-cluster-join-existing`, the labels on the pod template that are used for discovery are removed.