### PR TITLE
fix windows build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -285,7 +285,6 @@ lazy val cli = crossProject(JSPlatform, NativePlatform)
             |  }
             |};
             |
-            |require("${output.getAbsolutePath.replaceAllLiterally("\\", "\\\\")}");
             |"""
           .stripMargin
           .replaceAllLiterally("\n", System.lineSeparator)
@@ -294,7 +293,7 @@ lazy val cli = crossProject(JSPlatform, NativePlatform)
 
       val entryFile = targetDir / "rp.js"
 
-      IO.write(entryFile, entry)
+      IO.write(entryFile, entry + IO.read(output))
 
       entryFile
     }


### PR DESCRIPTION
nexe doesn't seem to like the `require`, so let's just build everything as a single js file. Verified working with @patrick-premont 

Will self-merge as this was used in the 1.0.0 windows release on Bintray.

Fixes #125