### PR TITLE
Container resource requests now use the correct key

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -273,7 +273,7 @@ object PodTemplate {
         Json(
           "resources" -> Json(
             "limits" -> cpuJson.deepmerge(memoryJson),
-            "request" -> cpuJson.deepmerge(memoryJson)))
+            "requests" -> cpuJson.deepmerge(memoryJson)))
       }
   }
 

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -430,7 +430,7 @@ object DeploymentJsonTest extends TestSuite {
               |    "cpu": 0.500000,
               |    "memory": 8192
               |  },
-              |  "request": {
+              |  "requests": {
               |    "cpu": 0.500000,
               |    "memory": 8192
               |  }
@@ -569,7 +569,7 @@ object DeploymentJsonTest extends TestSuite {
               |      "cpu":0.100000,
               |      "memory":200
               |    },
-              |    "request": {
+              |    "requests": {
               |      "cpu":0.100000,
               |      "memory":200
               |    }
@@ -591,7 +591,7 @@ object DeploymentJsonTest extends TestSuite {
               |    "limits": {
               |      "memory":200
               |    },
-              |    "request": {
+              |    "requests": {
               |      "memory":200
               |    }
               |   }
@@ -612,7 +612,7 @@ object DeploymentJsonTest extends TestSuite {
               |    "limits": {
               |      "cpu":2.50000
               |    },
-              |    "request": {
+              |    "requests": {
               |      "cpu":2.50000
               |    }
               |   }


### PR DESCRIPTION
I've changed the key name, which should be`requests`, not `request`.

See the Kubernetes documentation: https://kubernetes-v1-4.github.io/docs/api-reference/v1/definitions/#_v1_resourcerequirements