### PR TITLE
Correctly deal with oauth2 tokens stored in docker credential helpers

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -166,7 +166,7 @@ object Main extends LazyLogging {
                       http,
                       creds,
                       generateDeploymentArgs.registryUseHttps,
-                      generateDeploymentArgs.registryValidateTls)(imageName, token = None).map(_._1)
+                      generateDeploymentArgs.registryValidateTls, imageName).map(_._1)
                   }
 
                 def getDockerConfig(imageName: String): Future[Config] = {

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -126,7 +126,13 @@ object Main extends LazyLogging {
                         entry <- creds.find(realm => docker.registryAuthNameMatches(registry, realm.registry))
                       } yield entry.credentials match {
                         case Left(raw) => HttpRequest.EncodedBasicAuth(raw)
-                        case Right((username, password)) => HttpRequest.BasicAuth(username, password)
+                        case Right((username, password)) => {
+                          if (username == "oauth2accesstoken")
+                            HttpRequest.BearerToken(password)
+                          else
+                            HttpRequest.BasicAuth(username, password)
+                        }
+
                       }
 
                     val dockerRegistryAuth = dockerRegistryArgsAuth.orElse(dockerRegistryFileAuth)


### PR DESCRIPTION
Even though gcloud credentials helper gives out credentials in "username -> password" format, it actually is an oauth2 token with username always being "oauth2accesstoken". This PR fixes reactive-cli to treat that correctly and allow pulling images from private gcr.io namespaces.

(Support case 10707)