### PR TITLE
Fix pullScope formatting which causes retrieving oauth tokens to fail

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/Image.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/Image.scala
@@ -38,5 +38,5 @@ case class Image(
   providedNamespace: Option[String],
   providedImage: String,
   providedRef: Option[ImageRef]) {
-  def pullScope: String = s"repository:$namespace/$image:pull"
+  def pullScope: String = s"repository:${namespace.map(ns => s"$ns/")}$image:pull"
 }


### PR DESCRIPTION
In Image.scala the change making namespace an optional value has caused the scope created by `pullScope` to contain a `Some()` which causes oauth token requests to fail in the DockerRepository.

This PR fixes this to make a valid scope whether the namespace is specified or not.

The issue has been logged here: https://github.com/lightbend/reactive-cli/issues/139