### PR TITLE
Fix HTTP header parsing, add cmdline flag to print out a stacktrace

### DIFF
--- a/cli/native/src/test/scala/com/lightbend/rp/reactivecli/http/NativeHttpTest.scala
+++ b/cli/native/src/test/scala/com/lightbend/rp/reactivecli/http/NativeHttpTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.http
+
+import scala.collection.immutable.Map
+import utest._
+
+object NativeHttpTest extends TestSuite {
+  val tests = this {
+    "Parse HTTP headers" - {
+      // No header field value
+      assert(NativeHttp.parseHeaders(Some("HTTP/1.1 200 OK\r\nAccept:")) == Map(
+        "Accept" -> ""
+      ))
+
+      // Real-world punctuation
+      assert(NativeHttp.parseHeaders(Some(
+        """HTTP/1.1 200 OK
+          |Date: Mon, 07 May 2018 08:43:13 GMT
+          |Expires: -1
+          |Cache-Control: private, max-age=0
+          |Content-Type: text/html; charset=ISO-8859-1""".stripMargin.replaceAll("\n", "\r\n"))) == Map(
+        "Date" -> "Mon, 07 May 2018 08:43:13 GMT",
+        "Expires" -> "-1",
+        "Cache-Control" -> "private, max-age=0",
+        "Content-Type" -> "text/html; charset=ISO-8859-1"
+      ))
+
+      // Multiline field values
+      assert(NativeHttp.parseHeaders(Some(
+        """HTTP/1.1 200 OK
+          |Date: Mon, 07 May 2018
+          | 08:43:13 GMT
+          |Expires: -1
+          |Cache-Control: private,
+          |               max-age=0
+          |Content-Type: text/html; charset=ISO-8859-1""".stripMargin.replaceAll("\n", "\r\n"))) == Map(
+        "Date" -> "Mon, 07 May 2018 08:43:13 GMT",
+        "Expires" -> "-1",
+        "Cache-Control" -> "private, max-age=0",
+        "Content-Type" -> "text/html; charset=ISO-8859-1"
+      ))
+    }
+  }
+}

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -226,8 +226,11 @@ object Main extends LazyLogging {
                   } yield validConfig
                 }
 
-                def configFailure(img: String, t: Throwable) =
+                def configFailure(img: String, t: Throwable) = {
+                  if (inputArgsMerged.stackTrace)
+                    t.printStackTrace()
                   s"Failed to obtain Docker config for $img, ${t.getMessage}"
+                }
 
                 Future
                   .sequence(generateDeploymentArgs.dockerImages.map(img => attempt(getDockerConfig(img)).map(c => img -> c)))

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -87,6 +87,10 @@ object InputArgs {
         .text("Sets the log level. Available: error, warn, info, debug, trace")
         .action((v, c) => c.copy(logLevel = v))
 
+      opt[Unit]("stacktrace")
+        .text("In case of failure, prints out a stack trace")
+        .action((v, c) => c.copy(stackTrace = true))
+
       help("help")
         .text("Print this help text")
 
@@ -491,5 +495,6 @@ object InputArgs {
  */
 case class InputArgs(
   logLevel: LogLevel = LogLevel.INFO,
+  stackTrace: Boolean = false,
   tlsCacertsPath: Option[String] = None,
   commandArgs: Option[CommandArgs] = None)


### PR DESCRIPTION
Previously, reactive-cli didn't handle multi-line HTTP header fields. This PR makes `rp` handle multi-line fields according to HTTP specification.

It also adds a flag "--stacktrace" which prints out the full stacktrace of an exception when `rp` fails. This should help to debug issues that we can't reproduce ourselves.