### PR TITLE
Retreives Config from a local image using the docker command

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -140,7 +140,7 @@ object Main extends LazyLogging {
                   System.out.println(s"jq support: ${if (jqAvail) "Available" else "Unavailable"}")
                 }
 
-              case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, _, _, _, _, _, _, Some(targetRuntimeArgs), _, _, _, _, _) =>
+              case generateDeploymentArgs @ GenerateDeploymentArgs(_, _, _, _, _, _, _, _, _, _, _, Some(targetRuntimeArgs), _, _, _, _, _, _) =>
                 implicit val httpSettings: HttpSettings =
                   inputArgs.tlsCacertsPath.fold(HttpSettings.default)(v => HttpSettings.default.copy(tlsCacertsPath = Some(v)))
 
@@ -191,6 +191,11 @@ object Main extends LazyLogging {
                   }
                 }
 
+                def getDockerLocalConfigIfEnabled(imageName: String): Future[Option[Config]] =
+                  if (generateDeploymentArgs.registryUseLocal)
+                    process.docker.inspectImageForConfig(imageName)
+                  else Future.successful(None)
+
                 def getDockerHostConfig(imageName: String): Future[Option[Config]] = {
                   implicit val httpSettingsWithDockerCredentials: HttpSettings = DockerEngine.applyDockerHostSettings(httpSettings, environment)
                   val http = Http.http(httpSettingsWithDockerCredentials)
@@ -216,7 +221,7 @@ object Main extends LazyLogging {
                     sbtConfig fallbackTo mavenConfig
                   }
 
-                  process.docker.inspectImageForConfig(imageName).flatMap(_.map(Future.successful).getOrElse(
+                  getDockerLocalConfigIfEnabled(imageName).flatMap(_.map(Future.successful).getOrElse(
                     getDockerHostConfig(imageName).flatMap(_.map(Future.successful).getOrElse(
                       getDockerRegistryConfig(imageName)))))
                     .flatMap(validateConfig _)

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -17,7 +17,7 @@
 package com.lightbend.rp.reactivecli.argparse
 
 import scala.collection.immutable.Seq
-import GenerateDeploymentArgs.{ DockerRegistryUseHttpsDefault, DockerRegistryValidateTlsDefault }
+import GenerateDeploymentArgs.{ DockerRegistryUseHttpsDefault, DockerRegistryValidateTlsDefault, DockerRegistryUseLocalDefault }
 
 /**
  * Base type which represents input argument for a specific command invoked by the user.
@@ -29,6 +29,7 @@ object VersionArgs extends CommandArgs
 object GenerateDeploymentArgs {
   val DockerRegistryUseHttpsDefault = true
   val DockerRegistryValidateTlsDefault = true
+  val DockerRegistryUseLocalDefault = false
 
   /**
    * Convenience method to set the [[GenerateDeploymentArgs]] values when parsing the complete user input.
@@ -79,4 +80,5 @@ case class GenerateDeploymentArgs(
   registryPassword: Option[String] = None,
   registryUseHttps: Boolean = DockerRegistryUseHttpsDefault,
   registryValidateTls: Boolean = DockerRegistryValidateTlsDefault,
+  registryUseLocal: Boolean = DockerRegistryUseLocalDefault,
   externalServices: Map[String, Seq[String]] = Map.empty) extends CommandArgs

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -287,6 +287,11 @@ object InputArgs {
             .optional()
             .action(GenerateDeploymentArgs.set((v, c) => c.copy(registryPassword = Some(v)))),
 
+          opt[Unit]("registry-use-local") /* note: this argument will apply for other targets */
+            .text("Checks the local docker registry before the remote registry. No authentication required, but does not verify that the image will be accessible at deployment time.")
+            .optional()
+            .action(GenerateDeploymentArgs.set((_, c) => c.copy(registryUseLocal = true))),
+
           opt[String]("service-api-version")
             .text(s"Sets the Service API version. Default: ${printFuture(KubernetesArgs.DefaultServiceApiVersion)}")
             .optional()
@@ -440,6 +445,11 @@ object InputArgs {
             .text("Specify username to access docker registry. Password must be specified also.")
             .optional()
             .action(GenerateDeploymentArgs.set((v, c) => c.copy(registryUsername = Some(v)))),
+
+          opt[Unit]("registry-use-local") /* note: this argument will apply for other targets */
+            .text("Checks the local docker registry before the remote registry. No authentication required, but does not verify that the image will be accessible at deployment time.")
+            .optional()
+            .action(GenerateDeploymentArgs.set((_, c) => c.copy(registryUseLocal = true))),
 
           opt[String]("transform-output")
             .text("A jq expression that will be applied to the configuration output. jq must be installed")

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/process/docker.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/process/docker.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.process
+
+import scala.concurrent.Future
+import com.lightbend.rp.reactivecli.concurrent._
+
+import com.lightbend.rp.reactivecli.docker.Config
+import argonaut.CodecJson
+
+object docker {
+  def inspectImageForConfig(imageName: String): Future[Option[Config]] =
+    exec("docker", "inspect", imageName).map {
+      case (_, json) =>
+        import _root_.argonaut.Argonaut._
+        json.decodeOption[List[CmdConfig]].flatMap(_.headOption.map(_.registryConfig))
+    }
+
+  import com.lightbend.rp.reactivecli.docker.{ Config => RegistryConfig }
+
+  private case class CmdConfig(Config: RegistryConfig.Cfg) {
+    def registryConfig: RegistryConfig = RegistryConfig(Config)
+  }
+
+  private object CmdConfig {
+    implicit val configUpperCodec: CodecJson[CmdConfig] = CodecJson.derive[CmdConfig]
+  }
+}


### PR DESCRIPTION
Created CmdConfig because Config didn't parse exactly right: the config field had to start with an uppercase.

Refactored the invocation of getDockerHostConfig and getDockerRegistryConfig to be more concise, so that adding a third method produced a more readable sequence.