### PR TITLE
Add Ubuntu 18.04 build

### DIFF
--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -95,7 +95,20 @@ object BuildInfo {
                       |  apt-get -y update && \\
                       |  apt-get -y install bc build-essential jq openjdk-8-jre-headless ca-certificates-java clang-3.8 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
                       |""".stripMargin,
-        target = DebBuildTarget(Seq("zesty", "artful"), "main", "bash,libre2-3,libunwind8,libcurl3", Seq.empty)))
+        target = DebBuildTarget(Seq("zesty", "artful"), "main", "bash,libre2-3,libunwind8,libcurl3", Seq.empty)),
+
+      BuildInfo(
+        name = "ubuntu-18-04",
+        baseImage = "ubuntu:18.04",
+        install = s"""|RUN \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install apt-transport-https dirmngr && \\
+                      |  echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list && \\
+                      |  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \\
+                      |  apt-get -y update && \\
+                      |  apt-get -y install bc build-essential jq openjdk-8-jre-headless ca-certificates-java clang-3.8 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
+                      |""".stripMargin,
+        target = DebBuildTarget(Seq("bionic"), "main", "bash,libre2-4,libunwind8,libcurl4", Seq.empty)))
 
   def initialize(root: File): Unit = {
     val ivyDir = root / "target" / ".ivy2" / "cache"

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -102,11 +102,11 @@ object BuildInfo {
         baseImage = "ubuntu:18.04",
         install = s"""|RUN \\
                       |  apt-get -y update && \\
-                      |  apt-get -y install apt-transport-https dirmngr && \\
+                      |  apt-get -y install apt-transport-https dirmngr ca-certificates && \\
                       |  echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list && \\
                       |  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \\
                       |  apt-get -y update && \\
-                      |  apt-get -y install bc build-essential jq openjdk-8-jre-headless ca-certificates-java clang-3.8 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
+                      |  apt-get -y install bc build-essential jq openjdk-8-jre-headless ca-certificates-java clang-3.9 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
                       |""".stripMargin,
         target = DebBuildTarget(Seq("bionic"), "main", "bash,libre2-4,libunwind8,libcurl4", Seq.empty)))
 


### PR DESCRIPTION
This change includes a custom docker image for build environment of Ubuntu 18.04, it is uploaded to bintray as `lightbend-docker-registry.bintray.io/rp/reactive-cli-build-ubuntu-18-04:latest`

Tested on VirtualBox VM.

Once this is merged, the next release of reactive-cli will have official Ubuntu 18.04 version.