### PR TITLE
Auto-reformatted code

### DIFF
--- a/cli/native/src/test/scala/com/lightbend/rp/reactivecli/http/NativeHttpTest.scala
+++ b/cli/native/src/test/scala/com/lightbend/rp/reactivecli/http/NativeHttpTest.scala
@@ -65,8 +65,7 @@ object NativeHttpTest extends TestSuite {
           |Date Mon, 07 May 2018 08:43:13 GMT
           |Expires: -1""".stripMargin.replaceAll("\n", "\r\n"))) == Map(
         "Accept" -> "*",
-        "Expires" -> "-1"
-      ))
+        "Expires" -> "-1"))
     }
   }
 }

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/process/dockercred.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/process/dockercred.scala
@@ -20,7 +20,7 @@ import java.util.NoSuchElementException
 import com.lightbend.rp.reactivecli.concurrent._
 import com.lightbend.rp.reactivecli.docker.DockerCredentials
 import com.lightbend.rp.reactivecli.files._
-import scala.collection.immutable.{Seq, Map}
+import scala.collection.immutable.{ Seq, Map }
 import scala.concurrent.Future
 import slogging._
 import argonaut._
@@ -67,7 +67,7 @@ object dockercred extends LazyLogging {
   }
 
   // Returns seq of tuples (server, username, helper) merged from multiple helpers
-  private def listAll(ks: Seq[String]) : Future[Seq[(String, String, String)]] = {
+  private def listAll(ks: Seq[String]): Future[Seq[(String, String, String)]] = {
     def step(ks: Seq[String]): Future[Map[String, (String, String)]] =
       if (ks.isEmpty)
         Future.successful(Map.empty)


### PR DESCRIPTION
This is the result of running `compile`. See the log:

    [info] Reformatted 2 Scala sources {file:/d/reactive-cli/}root(compile).