### PR TITLE
Support new fake GCloud oauth username

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/Main.scala
@@ -195,7 +195,7 @@ object Main extends LazyLogging {
           } yield entry.credentials match {
             case Left(raw) => HttpRequest.EncodedBasicAuth(raw)
             case Right((username, password)) => {
-              if (username == "oauth2accesstoken")
+              if (username == "oauth2accesstoken" || username == "_dcgcloud_token")
                 HttpRequest.BearerToken(password)
               else
                 HttpRequest.BasicAuth(username, password)


### PR DESCRIPTION
Google Cloud SDK recently changed username reported by their `docker-credential-gcloud` utlity from `oauth2accesstoken` to `_dcgcloud_token`. This PR fixes our currently broken authentication with gcloud.

Hardcoding these usernames is not the nicest solution, but I don't know what else can we do since they have to be treated differently - instead of basic username+password auth we must do bearer token auth with password as a token.