### PR TITLE
Add annotations to k8s and marathon resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.11.11
+  - 2.11.12
 services:
   - docker
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val Names = new {
 }
 
 lazy val Versions = new {
-  val argonaut  = "6.2.2"
+  val argonaut  = "6.2.1"
   val fastparse = "1.0.0"
   val nodejs    = "0.4.2"
   val scala     = "2.11.12"

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val Names = new {
 }
 
 lazy val Versions = new {
-  val argonaut  = "6.2.1"
+  val argonaut  = "6.2.2"
   val fastparse = "1.0.0"
   val nodejs    = "0.4.2"
   val scala     = "2.11.12"

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/annotations/Annotation.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/annotations/Annotation.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.annotations
+
+case class Annotation(key: String, value: String)

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -359,9 +359,18 @@ object PodTemplate {
       else
         labels
 
+    val annotationsToUse = Option(
+      annotations
+        .annotations
+        .map(a => (a.key, jString(a.value)))
+        .toMap)
+      .filter(_.nonEmpty)
+
     PodTemplate(
       Json(
-        "metadata" -> Json("labels" -> labelsToUse.asJson),
+        "metadata" -> (
+          ("labels" -> labelsToUse.asJson) ->:
+          ("annotations" :=? annotationsToUse) ->?: jEmptyObject),
         "spec" -> Json(
           "restartPolicy" -> restartPolicy.asJson,
           "containers" -> jArrayElements(

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/marathon/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/marathon/package.scala
@@ -118,11 +118,18 @@ package object marathon {
                             sortedPaths.nonEmpty.option(Seq(s"HAPROXY_${i}_PATH" -> jString(sortedPaths.mkString(" ")), s"HAPROXY_${i}_HTTP_BACKEND_PROXYPASS_PATH" -> jString(sortedPaths.mkString(" ")))).getOrElse(Seq.empty)).flatten
                       }
 
+                  val annotationsToUse =
+                    annotations
+                      .annotations
+                      .map(a => a.key -> jString(a.value))
+                      .toList
+
                   val labels = List(
                     "APP_NAME" -> jString(appName),
                     "APP_NAME_VERSION" -> jString(appNameVersion)) ++
                     annotations.akkaClusterBootstrapSystemName.fold(List.empty[(String, Json)])(system => List("ACTOR_SYSTEM_NAME" -> jString(system))) ++
-                    endpointLabels
+                    endpointLabels ++
+                    annotationsToUse
 
                   val enableChecks =
                     annotations.modules.contains(Module.Status) && annotations.modules.contains(Module.AkkaManagement)

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
@@ -176,6 +176,10 @@ object AnnotationsTest extends TestSuite {
               "com.lightbend.rp.endpoints.2.name" -> "ep3",
               "com.lightbend.rp.endpoints.2.protocol" -> "udp",
               "com.lightbend.rp.endpoints.2.port" -> "1234",
+              "com.lightbend.rp.annotations.0.key" -> "annotationKey0",
+              "com.lightbend.rp.annotations.0.value" -> "annotationValue0",
+              "com.lightbend.rp.annotations.1.key" -> "annotationKey1",
+              "com.lightbend.rp.annotations.1.value" -> "annotationValue1",
               "com.lightbend.rp.modules.common.enabled" -> "true",
               "com.lightbend.rp.modules.another-one.enabled" -> "false",
               "com.lightbend.rp.akka-cluster-bootstrap.system-name" -> "test"),
@@ -195,6 +199,9 @@ object AnnotationsTest extends TestSuite {
                 "ep2" -> TcpEndpoint(1, "ep2", 1234),
                 "ep3" -> UdpEndpoint(2, "ep3", 1234)),
               secrets = Seq.empty,
+              annotations = Vector(
+                Annotation("annotationKey0", "annotationValue0"),
+                Annotation("annotationKey1", "annotationValue1")),
               privileged = true,
               environmentVariables = Map(
                 "testing1" -> LiteralEnvironmentVariable("testingvalue1"),

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -47,6 +47,9 @@ object DeploymentJsonTest extends TestSuite {
     cpu = Some(0.5D),
     endpoints = endpoints,
     secrets = Seq(Secret("acme.co", "my-secret")),
+    annotations = Seq(
+      Annotation("annotationKey0", "annotationValue0"),
+      Annotation("annotationKey1", "annotationValue1")),
     privileged = true,
     environmentVariables = Map(
       "testing1" -> LiteralEnvironmentVariable("testingvalue1")),
@@ -126,6 +129,10 @@ object DeploymentJsonTest extends TestSuite {
               |        "labels": {
               |          "appName": "friendimpl",
               |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |        },
+              |        "annotations": {
+              |          "annotationKey0": "annotationValue0",
+              |          "annotationKey1": "annotationValue1"
               |        }
               |      },
               |      "spec": {

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
@@ -26,7 +26,7 @@ import utest._
 import Argonaut._
 
 object IngressJsonTest extends TestSuite {
-  def createAnnotations(appName: String, urlOne: String, urlTwo: String) =
+  def createAnnotations(appName: String, urlOne: String, urlTwo: String): Annotations =
     Annotations(
       namespace = Some("chirper"),
       applications = Vector.empty,


### PR DESCRIPTION
Annotations are pulled from the docker labels:

    com.lightbend.rp.annotations.0.key=mykey
    com.lightbend.rp.annotations.0.value=myval

This will annotate the PodSpec in Kubernetes resources:

    "metadata": {
        "annotations": {
            "meykey": "myval"
        }

For marathon, it will be appended to the list of labels.