### PR TITLE
Bump Scala Native and Scala.js versions

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,18 +1,8 @@
-val Versions = new {
-  val sbtBintray         = "0.5.1"
-  val sbtCrossProject    = "0.3.0"
-  val sbtHeader          = "3.0.1"
-  val sbtNativePackager  = "1.2.0"
-  val sbtRelease         = "1.0.6"
-  val sbtScalaNative     = "0.3.6"
-  val sbtScalaJS         = "0.3.0"
-  val sbtScalariform     = "1.8.0"
-}
-
-addSbtPlugin("com.github.gseitz"  % "sbt-release"              % Versions.sbtRelease)
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"               % Versions.sbtHeader)
-addSbtPlugin("org.foundweekends"  % "sbt-bintray"              % Versions.sbtBintray)
-addSbtPlugin("org.portable-scala" % "sbt-crossproject"         % Versions.sbtCrossProject)
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"         % Versions.sbtScalaNative)
-addSbtPlugin("org.scalariform"    % "sbt-scalariform"          % Versions.sbtScalariform)
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % Versions.sbtScalaJS)
+addSbtPlugin("com.github.gseitz"  % "sbt-release"                   % "1.0.6")
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"                    % "3.0.1")
+addSbtPlugin("org.foundweekends"  % "sbt-bintray"                   % "0.5.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.23")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.7")
+addSbtPlugin("org.scalariform"    % "sbt-scalariform"               % "1.8.0")


### PR DESCRIPTION
Per title. Built locally, seems to be working:

**JS**

```bash
~/work/lightbend/reactive-cli#bump-scala $ node cli/js/target/rp.js --help
reactive-cli 1.3.1-SNAPSHOT
Usage: reactive-cli [version|generate-kubernetes-resources|generate-marathon-configuration] [options] <args>...

  --cainfo <value>         Path to the CA certs for TLS validation purposes
  -l, --loglevel <value>   Sets the log level. Available: error, warn, info, debug, trace
  --stacktrace             In case of failure, prints out a stack trace
  --help                   Print this help text
Command: version
Outputs the program's version
Command: generate-kubernetes-resources [options] docker-images
Generate Kubernetes resource files (Pod Controllers, Services) for kubectl
  docker-images            Docker images to be deployed. Format: [<registry host>/][<repo>/]image[:tag]
  --application <value>    Application to generate resources for. If omitted, resources are generated for the default application. If generating for an alternate application, its name will be part of the generated resource names
  --deployment-type <value>
                           Sets the deployment type. Default: canary; Available: canary, blue-green, rolling
  --env <value>            Sets an environment variable. Format: NAME=value
  --external-service <value>
                           Declares an external service address. Format: NAME=value
  --generate-all           Generate all resource types (excluding namespaces which must be explicitly enabled)
  --generate-ingress       Generate Ingress resources
  --generate-namespaces    Generate Namespace resources
  --generate-pod-controllers
                           Generate PodController resources
  --generate-services      Generate Service resources
  --ingress-annotation <value>
                           Adds an annotation to the generated Ingress resources. Format: NAME=value
  --ingress-api-version <value>
                           Sets the Ingress API version. Default: Future(<not completed>)
  --ingress-host <value>   Add a host to the generated Ingress resource
  --ingress-name <value>   Specifies the name for the generated Ingress resource
  --ingress-path-suffix <value>
                           Appends the expression specified to the paths of the generated Ingress resources
  --ingress-tls-secret <value>
                           Add a TLS secret to the generated Ingress resources 
  --akka-cluster-join-existing
                           When provided, the pod controller will only join an already formed Akka Cluster
  --name <value>           Uses specified name for generated resources instead of name in the Docker image
  --namespace <value>      Resources will be generated with the supplied namespace
  -o, --output <value>     Specify the output directory for the generated resources
  --apps-api-version <value>
                           Sets the apps (e.g. Deployment) API version. Default: Future(<not completed>)
  --batch-api-version <value>
                           Sets the batch (e.g. Job) API version. Default: Future(<not completed>)
  --pod-controller-image-pull-policy <value>
                           Sets the Docker image pull policy for Pod Controller resources. Supported: Never, IfNotPresent, Always
  --pod-controller-restart-policy <value>
                           Sets restart policy for Pod Controller resources. Supported: Never, OnFailure, Always, Default
  --pod-controller-replicas <value>
                           Sets the number of replicas for the Pod Controller resources. If Akka Cluster Bootstrap is enabled, this must be set to 2 or greater unless `--akka-cluster-join-existing` is provided
  --pod-controller-type <value>
                           Sets the type of pod controller to generate. Default: deployment; Available: deployment, job
  --registry-disable-https
                           Disables HTTPS when accessing docker registry
  --registry-disable-tls-validation
                           Disables TLS cert validation when accessing docker registry through HTTPS
  --registry-username <value>
                           Specify username to access docker registry. Password must be specified also.
  --registry-password <value>
                           Specify password to access docker registry. Username must be specified also.
  --registry-use-local     Checks the local docker registry before the remote registry. No authentication required, but does not verify that the image will be accessible at deployment time.
  --service-api-version <value>
                           Sets the Service API version. Default: Future(<not completed>)
  --service-cluster-ip <value>
                           Sets the clusterIP value for Service resources
  --service-load-balancer-ip <value>
                           Sets the loadBalancerIP for Service resources
  --service-type <value>   Sets the type for Service resources
  --version <value>        Uses specified version tag for generated resources instead of version in the docker image
  --transform-ingress <value>
                           A jq expression that will be applied to Ingress resources. jq must be installed
  --transform-namespaces <value>
                           A jq expression that will be applied to Namespace resources. jq must be installed
  --transform-pod-controllers <value>
                           A jq expression that will be applied to Pod Controller resources. jq must be installed
  --transform-services <value>
                           A jq expression that will be applied to Service resources. jq must be installed
Command: generate-marathon-configuration [options] docker-images
Generate DC/OS Marathon configuration
  docker-images            Docker images to be deployed. Format: [<registry host>/][<repo>/]image[:tag]
  --application <value>    Application to generate resources for. If omitted, resources are generated for the default application. If generating for an alternate application, its name will be part of the generated configuration
  --deployment-type <value>
                           Sets the deployment type. Default: rolling; Available: canary, blue-green, rolling
  --env <value>            Sets an environment variable. Format: NAME=value
  --external-service <value>
                           Declares an external service address. Format: NAME=value
  --akka-cluster-join-existing
                           When provided, the pod controller will only join an already formed Akka Cluster
  --instances <value>      Sets the number of instances for the app. If Akka Cluster Bootstrap is enabled, this must be set to 2 or greater unless `--akka-cluster-join-existing` is provided
  --marathon-lb-group <value>
                           Specify the `HAPROXY_GROUP` value for any marathon-lb configuration
  --marathon-lb-host <value>
                           Add a host to the generated marathon-lb configuration
  --name <value>           Uses specified name for generated resources instead of name in the Docker image
  --namespace <value>      Resources will be generated with the supplied namespace (marathon group)
  -o, --output <value>     Specify the output file for the generated configuration
  --registry-disable-https
                           Disables HTTPS when accessing docker registry
  --registry-disable-tls-validation
                           Disables TLS cert validation when accessing docker registry through HTTPS
  --registry-force-pull <value>
                           When provided, Marathon will be configured to always pull from the Docker registry before running the container
  --registry-password <value>
                           Specify password to access docker registry. Username must be specified also.
  --registry-username <value>
                           Specify username to access docker registry. Password must be specified also.
  --registry-use-local     Checks the local docker registry before the remote registry. No authentication required, but does not verify that the image will be accessible at deployment time.
  --transform-output <value>
                           A jq expression that will be applied to the configuration output. jq must be installed
  --version <value>        Uses specified version tag for generated resources instead of version in the docker image
-> 0
```

**Native**

```bash
~/work/lightbend/reactive-cli#bump-scala $ ./cli/native/target/output/bin/rp --help
reactive-cli 1.3.1-SNAPSHOT
Usage: reactive-cli [version|generate-kubernetes-resources|generate-marathon-configuration] [options] <args>...

  --cainfo <value>         Path to the CA certs for TLS validation purposes
  -l, --loglevel <value>   Sets the log level. Available: error, warn, info, debug, trace
  --stacktrace             In case of failure, prints out a stack trace
  --help                   Print this help text
Command: version
Outputs the program's version
Command: generate-kubernetes-resources [options] docker-images
Generate Kubernetes resource files (Pod Controllers, Services) for kubectl
  docker-images            Docker images to be deployed. Format: [<registry host>/][<repo>/]image[:tag]
  --application <value>    Application to generate resources for. If omitted, resources are generated for the default application. If generating for an alternate application, its name will be part of the generated resource names
  --deployment-type <value>
                           Sets the deployment type. Default: canary; Available: canary, blue-green, rolling
  --env <value>            Sets an environment variable. Format: NAME=value
  --external-service <value>
                           Declares an external service address. Format: NAME=value
  --generate-all           Generate all resource types (excluding namespaces which must be explicitly enabled)
  --generate-ingress       Generate Ingress resources
  --generate-namespaces    Generate Namespace resources
  --generate-pod-controllers
                           Generate PodController resources
  --generate-services      Generate Service resources
  --ingress-annotation <value>
                           Adds an annotation to the generated Ingress resources. Format: NAME=value
  --ingress-api-version <value>
                           Sets the Ingress API version. Default: extensions/v1beta1
  --ingress-host <value>   Add a host to the generated Ingress resource
  --ingress-name <value>   Specifies the name for the generated Ingress resource
  --ingress-path-suffix <value>
                           Appends the expression specified to the paths of the generated Ingress resources
  --ingress-tls-secret <value>
                           Add a TLS secret to the generated Ingress resources 
  --akka-cluster-join-existing
                           When provided, the pod controller will only join an already formed Akka Cluster
  --name <value>           Uses specified name for generated resources instead of name in the Docker image
  --namespace <value>      Resources will be generated with the supplied namespace
  -o, --output <value>     Specify the output directory for the generated resources
  --apps-api-version <value>
                           Sets the apps (e.g. Deployment) API version. Default: apps/v1beta2
  --batch-api-version <value>
                           Sets the batch (e.g. Job) API version. Default: batch/v1
  --pod-controller-image-pull-policy <value>
                           Sets the Docker image pull policy for Pod Controller resources. Supported: Never, IfNotPresent, Always
  --pod-controller-restart-policy <value>
                           Sets restart policy for Pod Controller resources. Supported: Never, OnFailure, Always, Default
  --pod-controller-replicas <value>
                           Sets the number of replicas for the Pod Controller resources. If Akka Cluster Bootstrap is enabled, this must be set to 2 or greater unless `--akka-cluster-join-existing` is provided
  --pod-controller-type <value>
                           Sets the type of pod controller to generate. Default: deployment; Available: deployment, job
  --registry-disable-https
                           Disables HTTPS when accessing docker registry
  --registry-disable-tls-validation
                           Disables TLS cert validation when accessing docker registry through HTTPS
  --registry-username <value>
                           Specify username to access docker registry. Password must be specified also.
  --registry-password <value>
                           Specify password to access docker registry. Username must be specified also.
  --registry-use-local     Checks the local docker registry before the remote registry. No authentication required, but does not verify that the image will be accessible at deployment time.
  --service-api-version <value>
                           Sets the Service API version. Default: v1
  --service-cluster-ip <value>
                           Sets the clusterIP value for Service resources
  --service-load-balancer-ip <value>
                           Sets the loadBalancerIP for Service resources
  --service-type <value>   Sets the type for Service resources
  --version <value>        Uses specified version tag for generated resources instead of version in the docker image
  --transform-ingress <value>
                           A jq expression that will be applied to Ingress resources. jq must be installed
  --transform-namespaces <value>
                           A jq expression that will be applied to Namespace resources. jq must be installed
  --transform-pod-controllers <value>
                           A jq expression that will be applied to Pod Controller resources. jq must be installed
  --transform-services <value>
                           A jq expression that will be applied to Service resources. jq must be installed
Command: generate-marathon-configuration [options] docker-images
Generate DC/OS Marathon configuration
  docker-images            Docker images to be deployed. Format: [<registry host>/][<repo>/]image[:tag]
  --application <value>    Application to generate resources for. If omitted, resources are generated for the default application. If generating for an alternate application, its name will be part of the generated configuration
  --deployment-type <value>
                           Sets the deployment type. Default: rolling; Available: canary, blue-green, rolling
  --env <value>            Sets an environment variable. Format: NAME=value
  --external-service <value>
                           Declares an external service address. Format: NAME=value
  --akka-cluster-join-existing
                           When provided, the pod controller will only join an already formed Akka Cluster
  --instances <value>      Sets the number of instances for the app. If Akka Cluster Bootstrap is enabled, this must be set to 2 or greater unless `--akka-cluster-join-existing` is provided
  --marathon-lb-group <value>
                           Specify the `HAPROXY_GROUP` value for any marathon-lb configuration
  --marathon-lb-host <value>
                           Add a host to the generated marathon-lb configuration
  --name <value>           Uses specified name for generated resources instead of name in the Docker image
  --namespace <value>      Resources will be generated with the supplied namespace (marathon group)
  -o, --output <value>     Specify the output file for the generated configuration
  --registry-disable-https
                           Disables HTTPS when accessing docker registry
  --registry-disable-tls-validation
                           Disables TLS cert validation when accessing docker registry through HTTPS
  --registry-force-pull <value>
                           When provided, Marathon will be configured to always pull from the Docker registry before running the container
  --registry-password <value>
                           Specify password to access docker registry. Username must be specified also.
  --registry-username <value>
                           Specify username to access docker registry. Password must be specified also.
  --registry-use-local     Checks the local docker registry before the remote registry. No authentication required, but does not verify that the image will be accessible at deployment time.
  --transform-output <value>
                           A jq expression that will be applied to the configuration output. jq must be installed
  --version <value>        Uses specified version tag for generated resources instead of version in the docker image
-> 0
```