### PR TITLE
Fix the build for Ubuntu 18.04

### DIFF
--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -5,6 +5,7 @@ import AdditionalIO._
 object BuildInfo {
   val Builds =
     Vector(
+
       MuslBuild.tgz("tgz"),
 
       MuslBuild.rpm("centos-6", "el6", "bash"),
@@ -94,9 +95,8 @@ object BuildInfo {
                       |  apt-get -y update && \\
                       |  apt-get -y install bc build-essential jq openjdk-8-jre-headless ca-certificates-java clang-3.8 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
                       |""".stripMargin,
-        target = DebBuildTarget(Seq("zesty", "artful"), "main", "bash,libre2-3,libunwind8,libcurl3", Seq.empty)))
+        target = DebBuildTarget(Seq("zesty", "artful"), "main", "bash,libre2-3,libunwind8,libcurl3", Seq.empty)),
 
-  /*
       BuildInfo(
         name = "ubuntu-18-04",
         baseImage = "ubuntu:18.04",
@@ -109,7 +109,7 @@ object BuildInfo {
                       |  apt-get -y install bc build-essential jq openjdk-8-jre-headless ca-certificates-java clang-3.9 libcurl4-openssl-dev libgc-dev libre2-dev libunwind8-dev sbt
                       |""".stripMargin,
         target = DebBuildTarget(Seq("bionic"), "main", "bash,libre2-4,libunwind8,libcurl4", Seq.empty)))
-  */
+
 
   private def initialize(root: File): Unit = {
     val ivyDir = root / "target" / ".ivy2" / "cache"

--- a/project/BuildTarget.scala
+++ b/project/BuildTarget.scala
@@ -203,7 +203,7 @@ case class DebBuildTarget(distributions: Seq[String], components: String, depend
           |
           |bash ./build
           |
-          |DPKGVER="$$(dpkg-query --showformat='$${Version}' -W dpkg)"
+          |DPKGVER="$$(dpkg --version | sed -e 's/^.*version \\([^ ]*\\) .*$$/\\1/;q')"
           |RECENTDPKG=0
           |dpkg --compare-versions "$$DPKGVER" "lt" "1.19" || RECENTDPKG=1
           |if [[ "$$RECENTDPKG" == "0" ]]

--- a/project/BuildTarget.scala
+++ b/project/BuildTarget.scala
@@ -203,7 +203,15 @@ case class DebBuildTarget(distributions: Seq[String], components: String, depend
           |
           |bash ./build
           |
-          |dpkg --build package
+          |DPKGVER="$$(dpkg-query --showformat='$${Version}' -W dpkg)"
+          |RECENTDPKG=0
+          |dpkg --compare-versions "$$DPKGVER" "lt" "1.19" || RECENTDPKG=1
+          |if [[ "$$RECENTDPKG" == "0" ]]
+          |then
+          |  dpkg-deb -b package
+          |else
+          |  dpkg-deb -b --no-uniform-compression package
+          |fi
           |
           |mv package.deb output/reactive-cli_$version-${distributions.mkString("-")}_$architecture.deb
           |""".stripMargin


### PR DESCRIPTION
At this time, Bintray cannot understand the new format generated
by default by dpkg 1.19 or later. There is a new flag that is
available in "dpkg-deb", but not in "dpkg"; also, the flag is
not understood by older versions. This patch detects the dpkg
version, and enables the compatibility flag when necessary.

Fixes #144