### PR TITLE
Fixes image URL parsing

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xms512M
+-J-Xmx4096M
+-J-Xss2M
+-J-XX:MaxMetaspaceSize=1024M

--- a/cli/native/src/test/scala/com/lightbend/rp/reactivecli/http/NativeHttpTest.scala
+++ b/cli/native/src/test/scala/com/lightbend/rp/reactivecli/http/NativeHttpTest.scala
@@ -65,8 +65,7 @@ object NativeHttpTest extends TestSuite {
           |Date Mon, 07 May 2018 08:43:13 GMT
           |Expires: -1""".stripMargin.replaceAll("\n", "\r\n"))) == Map(
         "Accept" -> "*",
-        "Expires" -> "-1"
-      ))
+        "Expires" -> "-1"))
     }
   }
 }

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/process/dockercred.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/process/dockercred.scala
@@ -20,7 +20,7 @@ import java.util.NoSuchElementException
 import com.lightbend.rp.reactivecli.concurrent._
 import com.lightbend.rp.reactivecli.docker.DockerCredentials
 import com.lightbend.rp.reactivecli.files._
-import scala.collection.immutable.{Seq, Map}
+import scala.collection.immutable.{ Seq, Map }
 import scala.concurrent.Future
 import slogging._
 import argonaut._
@@ -67,7 +67,7 @@ object dockercred extends LazyLogging {
   }
 
   // Returns seq of tuples (server, username, helper) merged from multiple helpers
-  private def listAll(ks: Seq[String]) : Future[Seq[(String, String, String)]] = {
+  private def listAll(ks: Seq[String]): Future[Seq[(String, String, String)]] = {
     def step(ks: Seq[String]): Future[Map[String, (String, String)]] =
       if (ks.isEmpty)
         Future.successful(Map.empty)

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/docker/DockerRegistryTest.scala
@@ -122,6 +122,19 @@ object DockerRegistryTest extends TestSuite {
               Some(ImageTag("3.5")))))
 
       assert(
+        DockerRegistry.parseImageUri("lightbend-docker-registry.bintray.io/allyourbase:1.0.arebelongtous") ==
+          Success(
+            Image(
+              "lightbend-docker-registry.bintray.io",
+              None,
+              "allyourbase",
+              ImageTag("1.0.arebelongtous"),
+              Some("lightbend-docker-registry.bintray.io"),
+              None,
+              "allyourbase",
+              Some(ImageTag("1.0.arebelongtous")))))
+
+      assert(
         DockerRegistry.parseImageUri("lightbend-docker.registry.bintray.io/conductr/oci-in-docker") ==
           Success(
             Image(


### PR DESCRIPTION
Fixes https://github.com/lightbend/reactive-cli/issues/175

Prior to this fix, it failed to parse lightbend-docker-registry.bintray.io/allyourbase:1.0.arebelongtous correctly.