### PR TITLE
Fixing bugs

### DIFF
--- a/cli/native/src/main/scala/com/lightbend/rp/reactivecli/Platform.scala
+++ b/cli/native/src/main/scala/com/lightbend/rp/reactivecli/Platform.scala
@@ -72,7 +72,7 @@ object Platform extends LazyLogging {
     }
 
   def encodeURI(uri: String): String = {
-    val enc = new URI(uri)
+    val enc = new URI(uri.replace(" ", "+"))
     enc.toASCIIString
   }
 

--- a/cli/native/src/test/scala/com/lightbend/rp/reactivecli/http/PlatformTest.scala
+++ b/cli/native/src/test/scala/com/lightbend/rp/reactivecli/http/PlatformTest.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.reactivecli.http
+
+import com.lightbend.rp.reactivecli.Platform
+import utest._
+
+object PlatformTest extends TestSuite {
+  val tests = this{
+    "Encode URI" - {
+      // No header field value
+      assert(Platform.encodeURI("https://exampl.com?service=Docker Registry") == "https://exampl.com?service=Docker+Registry")
+
+    }
+  }
+}

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/docker/DockerRegistry.scala
@@ -86,17 +86,7 @@ object DockerRegistry extends LazyLogging {
             providedRef = providedRef)
         }
       }
-
     }
-
-
-
-
-
-
-
-
-
   }
 
   private def getBlob(http: HttpExchange, credentials: Option[HttpRequest.Auth], useHttps: Boolean, validateTls: Boolean, img: Image, digest: String): Future[(HttpResponse, Option[HttpRequest.BearerToken])] =
@@ -203,6 +193,7 @@ object DockerRegistry extends LazyLogging {
 
         maybeResponse.recover {
           case t: Throwable =>
+            logger.trace("Error: {}", t)
             logger.error(s"Unable to obtain an OAuth token (${response.statusCode}${response.body.fold("")(" " + _)})")
 
             response -> token

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/http/Http.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/http/Http.scala
@@ -32,8 +32,8 @@ object Http extends LazyLogging {
   def apply(request: HttpRequest)(implicit settings: HttpSettings): Future[HttpResponse] = doRequest(request, Nil)
 
   private def doRequest(
-    request: HttpRequest,
-    visitedUrls: List[String])(implicit settings: HttpSettings): Future[HttpResponse] = {
+                         request: HttpRequest,
+                         visitedUrls: List[String])(implicit settings: HttpSettings): Future[HttpResponse] = {
     val isFollowRedirect = request.requestFollowRedirects.getOrElse(settings.followRedirect)
 
     Platform
@@ -50,17 +50,8 @@ object Http extends LazyLogging {
             logger.debug("No more redirects allowed")
             Future.failed(InfiniteRedirect(visitedUrls))
           } else {
-            println(location)
-            if (location.indexOf("X-Amz-Credential") > -1) {
-              // S3 based registry doesn't accept authorization header on redirect
-              logger.debug("Performing S3 redirect")
-              doRequest(
-                HttpRequest(location, tlsValidationEnabled = Some(true), requestFollowRedirects = request.requestFollowRedirects),
-                location :: visitedUrls)
-            } else {
-              doRequest(
-                request.copy(location), location :: visitedUrls)
-            }
+            doRequest(
+              request.copy(location), location :: visitedUrls)
           }
         } else {
           Future.successful(response)

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/http/Http.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/http/Http.scala
@@ -18,9 +18,11 @@ package com.lightbend.rp.reactivecli.http
 
 import com.lightbend.rp.reactivecli.Platform
 import com.lightbend.rp.reactivecli.concurrent._
+import slogging.LazyLogging
+
 import scala.concurrent.Future
 
-object Http {
+object Http extends LazyLogging {
   type HttpExchange = HttpRequest => Future[HttpResponse]
 
   case class InfiniteRedirect(visited: List[String]) extends RuntimeException(s"Infinte redirect detected: $visited")
@@ -44,12 +46,22 @@ object Http {
 
           val location = response.headers("Location")
 
-          if (visitedUrls.contains(location) || visitedUrls.length >= settings.maxRedirects)
+          if (visitedUrls.contains(location) || visitedUrls.length >= settings.maxRedirects) {
+            logger.debug("No more redirects allowed")
             Future.failed(InfiniteRedirect(visitedUrls))
-          else
-            doRequest(
-              HttpRequest(location).copy(requestFollowRedirects = request.requestFollowRedirects),
-              location :: visitedUrls)
+          } else {
+            println(location)
+            if (location.indexOf("X-Amz-Credential") > -1) {
+              // S3 based registry doesn't accept authorization header on redirect
+              logger.debug("Performing S3 redirect")
+              doRequest(
+                HttpRequest(location, tlsValidationEnabled = Some(true), requestFollowRedirects = request.requestFollowRedirects),
+                location :: visitedUrls)
+            } else {
+              doRequest(
+                request.copy(location), location :: visitedUrls)
+            }
+          }
         } else {
           Future.successful(response)
         }


### PR DESCRIPTION
Hi I managed to fix some bugs which came up during using the tool.

Fix include:
* When using token authorisation the url for fetching the token is invalid. This will came up when your service name has spaces eg. "Docker Registry"  in the registry:2 image configuration.
* Tool does not follow redirects correctly. Credentials used in previous call are not copied to the next one.
* S3 support. During calling for blob date registry redirects to the s3 resource with tokens available in parameters. In that case authorisation header should be removed.

Hope this helps someone.