### PR TITLE
Authentication fixes: Basic & EncodedBasic

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/http/Http.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/http/Http.scala
@@ -32,8 +32,8 @@ object Http extends LazyLogging {
   def apply(request: HttpRequest)(implicit settings: HttpSettings): Future[HttpResponse] = doRequest(request, Nil)
 
   private def doRequest(
-                         request: HttpRequest,
-                         visitedUrls: List[String])(implicit settings: HttpSettings): Future[HttpResponse] = {
+    request: HttpRequest,
+    visitedUrls: List[String])(implicit settings: HttpSettings): Future[HttpResponse] = {
     val isFollowRedirect = request.requestFollowRedirects.getOrElse(settings.followRedirect)
 
     Platform

--- a/project/BuildInfo.scala
+++ b/project/BuildInfo.scala
@@ -110,7 +110,6 @@ object BuildInfo {
                       |""".stripMargin,
         target = DebBuildTarget(Seq("bionic"), "main", "bash,libre2-4,libunwind8,libcurl4", Seq.empty)))
 
-
   private def initialize(root: File): Unit = {
     val ivyDir = root / "target" / ".ivy2" / "cache"
     val sbtDir = root / "target" / ".sbt" / "launchers"
@@ -146,7 +145,7 @@ object BuildInfo {
   private def forName(name: String, log: Logger): Seq[BuildInfo] = {
     Builds.find(_.name == name) match {
       case Some(b) => Seq(b)
-      case None    => log.error(s"Unable to find build for name: $name"); Nil
+      case None => log.error(s"Unable to find build for name: $name"); Nil
     }
   }
 


### PR DESCRIPTION
Some docker repositories rely on basic authentication, notably AWS ECR; the current code would fail to use basic auth credentials to authenticate. Also the code was failing to use the encoded credentials saved in `~/.docker/config.json` by "docker login" in some cases.