### PR TITLE
Switch from akka.discovery.method

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -78,7 +78,7 @@ object PodTemplate {
         Map(
           "RP_JAVA_OPTS" -> LiteralEnvironmentVariable(
             Seq(
-              s"-Dakka.discovery.method=kubernetes-api",
+              s"-Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api",
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName",
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas",
               akkaClusterBootstrapSystemName.fold("-Dakka.discovery.kubernetes-api.pod-label-selector=appName=%s")(systemName => s"-Dakka.discovery.kubernetes-api.pod-label-selector=actorSystemName=$systemName"),

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariables.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariables.scala
@@ -57,7 +57,7 @@ object RpEnvironmentVariables {
     else
       Map(
         "RP_JAVA_OPTS" -> Seq(
-          s"-Dakka.discovery.method=marathon-api",
+          s"-Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=marathon-api",
           s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName",
           s"-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas",
           akkaClusterBootstrapSystemName.fold("-Dakka.discovery.marathon-api.app-label-query=APP_NAME==%s")(systemName => s"-Dakka.discovery.marathon-api.app-label-query=ACTOR_SYSTEM_NAME==$systemName"),

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -398,6 +398,326 @@ object DeploymentJsonTest extends TestSuite {
           }
           assert(result == Deployment("friendimpl-v3-2-1-snapshot", expectedJson, JsonTransform.noop))
         }
+
+        "should generate application health check given status module" - {
+          val expectedJson =
+            """
+              |{
+              |  "apiVersion": "apps/v1beta2",
+              |  "kind": "Deployment",
+              |  "metadata": {
+              |    "name": "friendimpl-v3-2-1-snapshot",
+              |    "labels": {
+              |      "appName": "friendimpl",
+              |      "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |    },
+              |    "namespace": "chirper"
+              |  },
+              |  "spec": {
+              |    "replicas": 1,
+              |    "selector": {
+              |      "matchLabels": {
+              |        "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |      }
+              |    },
+              |    "template": {
+              |      "metadata": {
+              |        "labels": {
+              |          "appName": "friendimpl",
+              |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |        },
+              |        "annotations": {
+              |          "annotationKey0": "annotationValue0",
+              |          "annotationKey1": "annotationValue1"
+              |        }
+              |      },
+              |      "spec": {
+              |        "restartPolicy": "Always",
+              |        "containers": [
+              |          {
+              |            "readinessProbe": {
+              |              "httpGet": {
+              |                 "path": "/platform-tooling/ready",
+              |                 "port": "akka-mgmt-http"
+              |               },
+              |               "periodSeconds": 10
+              |            },
+              |            "name": "friendimpl",
+              |            "livenessProbe": {
+              |              "httpGet": {
+              |                "path": "/platform-tooling/healthy",
+              |                "port": "akka-mgmt-http"
+              |              },
+              |              "periodSeconds": 10,
+              |              "initialDelaySeconds": 60
+              |            },
+              |            "image": "my-repo/my-image",
+              |            "ports": [
+              |              {
+              |                "containerPort": 10000,
+              |                "name": "ep1"
+              |              },
+              |              {
+              |                "containerPort": 1234,
+              |                "name": "ep2"
+              |              },
+              |              {
+              |                "containerPort": 10001,
+              |                "name": "ep3"
+              |              }
+              |            ],
+              |            "resources": {
+              |              "limits": {
+              |                "cpu": 0.5,
+              |                "memory": 8192
+              |              },
+              |              "requests": {
+              |                "cpu": 0.5,
+              |                "memory": 8192
+              |              }
+              |            },
+              |            "imagePullPolicy": "Never",
+              |            "volumeMounts": [
+              |              {
+              |                "mountPath": "/rp/secrets/acme-co",
+              |                "name": "secret-acme-co"
+              |              }
+              |            ],
+              |            "env": [
+              |              {
+              |                "name": "RP_APP_NAME",
+              |                "value": "friendimpl"
+              |              },
+              |              {
+              |                "name": "RP_APP_TYPE",
+              |                "value": "basic"
+              |              },
+              |              {
+              |                "name": "RP_APP_VERSION",
+              |                "value": "3.2.1-SNAPSHOT"
+              |              },
+              |              {
+              |                 "name": "RP_DYN_JAVA_OPTS",
+              |                 "value": "-Dakka.discovery.kubernetes-api.pod-namespace=$RP_NAMESPACE"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINTS",
+              |                "value": "EP1,EP2,EP3"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINTS_COUNT",
+              |                "value": "3"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_0_BIND_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_0_BIND_PORT",
+              |                "value": "10000"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_0_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_0_PORT",
+              |                "value": "10000"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_1_BIND_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_1_BIND_PORT",
+              |                "value": "1234"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_1_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_1_PORT",
+              |                "value": "1234"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_2_BIND_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_2_BIND_PORT",
+              |                "value": "10001"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_2_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_2_PORT",
+              |                "value": "10001"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP1_BIND_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP1_BIND_PORT",
+              |                "value": "10000"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP1_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP1_PORT",
+              |                "value": "10000"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP2_BIND_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP2_BIND_PORT",
+              |                "value": "1234"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP2_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP2_PORT",
+              |                "value": "1234"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP3_BIND_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP3_BIND_PORT",
+              |                "value": "10001"
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP3_HOST",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_ENDPOINT_EP3_PORT",
+              |                "value": "10001"
+              |              },
+              |              {
+              |                "name": "RP_JAVA_OPTS",
+              |                "value": "-Dconfig.resource=my-config.conf -Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1 -Dakka.discovery.kubernetes-api.pod-label-selector=appName=%s"
+              |              },
+              |              {
+              |                "name": "RP_KUBERNETES_POD_IP",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "status.podIP"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_KUBERNETES_POD_NAME",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "metadata.name"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                 "name": "RP_MODULES",
+              |                 "value": "akka-cluster-bootstrapping,akka-management,status"
+              |              },
+              |              {
+              |                "name": "RP_NAMESPACE",
+              |                "valueFrom": {
+              |                  "fieldRef": {
+              |                    "fieldPath": "metadata.namespace"
+              |                  }
+              |                }
+              |              },
+              |              {
+              |                "name": "RP_PLATFORM",
+              |                "value": "kubernetes"
+              |              },
+              |              {
+              |                "name": "testing1",
+              |                "value": "testingvalue1"
+              |              }
+              |            ]
+              |          }
+              |        ],
+              |        "volumes": [
+              |          {
+              |            "name": "secret-acme-co",
+              |            "secret": {
+              |              "secretName": "acme.co"
+              |            }
+              |          }
+              |        ]
+              |      }
+              |    }
+              |  }
+              |}
+            """.stripMargin.parse.right.get
+          val result = Deployment.generate(annotations.copy(
+            modules = Set("akka-management", "status", "akka-cluster-bootstrapping")
+          ), "apps/v1beta2", None, imageName,
+            PodTemplate.ImagePullPolicy.Never, PodTemplate.RestartPolicy.Default, noOfReplicas = 1, Map.empty, CanaryDeploymentType, JsonTransform.noop, false).toOption.get
+          if (result.json != expectedJson) {
+            println(s"deployment K8 JSON:\n" + PrettyParams.spaces2.copy(colonLeft = "").pretty(result.json))
+          }
+          assert(result == Deployment("friendimpl-v3-2-1-snapshot", expectedJson, JsonTransform.noop))
+        }
+
         "should fail if application name is not defined" - {
           val invalid = annotations.copy(appName = None)
           assert(Deployment.generate(invalid, "apps/v1beta2", None, imageName, PodTemplate.ImagePullPolicy.Never, PodTemplate.RestartPolicy.Default, 1, Map.empty, CanaryDeploymentType, JsonTransform.noop, false).toOption.isEmpty)

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariablesTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariablesTest.scala
@@ -109,7 +109,7 @@ object RpEnvironmentVariablesTest extends TestSuite {
         Map(
           "RP_ENDPOINT_0_BIND_PORT" -> "$PORT_EP",
           "RP_ENDPOINTS" -> "EP1", "RP_APP_VERSION" -> "3.2.1-SNAPSHOT",
-          "RP_JAVA_OPTS" -> "-Dakka.discovery.method=marathon-api -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=3 -Dakka.discovery.marathon-api.app-label-query=APP_NAME==%s",
+          "RP_JAVA_OPTS" -> "-Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=marathon-api -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=3 -Dakka.discovery.marathon-api.app-label-query=APP_NAME==%s",
           "RP_PLATFORM" -> "mesos",
           "RP_ENDPOINT_EP1_PORT" -> "$PORT_EP",
           "RP_MODULES" -> "akka-cluster-bootstrapping",


### PR DESCRIPTION
to akka.management.cluster.bootstrap.contact-point-discovery.discovery-method.

For Akka Cluster Bootstrap we can use more specific setting `contact-point-discovery.discovery-method` instead of taking over the entire `akka.discovery.method`. This frees up `akka.discovery.method` to be used for generic service discovery setting for example to chain config and DNS.

Fixes #173
Ref https://github.com/akka/akka-management/issues/316

This was tested using the integration testing on reactive-lib https://github.com/lightbend/reactive-lib/pull/106

/cc @lightbend/play-lagom 
