### PR TITLE
 Rename appName to app, and add akka.lightbend.com/service-name label

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
@@ -58,7 +58,7 @@ object Deployment {
         val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
 
         val labels = Map(
-          "appName" -> appName,
+          "app" -> appName,
           "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
 
         val podTemplate =
@@ -87,7 +87,7 @@ object Deployment {
               (appNameVersion, Json("appNameVersion" -> appNameVersion.asJson))
 
             case RollingDeploymentType =>
-              (appName, Json("appName" -> appName.asJson))
+              (appName, Json("app" -> appName.asJson))
           }
 
         Deployment(

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
@@ -57,9 +57,17 @@ object Deployment {
         val appName = serviceName(rawAppName)
         val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
 
+        val serviceResourceName =
+          deploymentType match {
+            case CanaryDeploymentType => appName
+            case BlueGreenDeploymentType => appNameVersion
+            case RollingDeploymentType => appName
+          }
+
         val labels = Map(
           "app" -> appName,
-          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
+          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map(
+            serviceNameLabel -> serviceResourceName))(system => Map(serviceNameLabel -> system))
 
         val podTemplate =
           PodTemplate.generate(

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
@@ -58,7 +58,7 @@ object Job {
         val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
 
         val labels = Map(
-          "appName" -> appName,
+          "app" -> appName,
           "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
 
         val podTemplate =

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
@@ -56,10 +56,17 @@ object Job {
       |@| restartPolicyValidation(restartPolicy)) { (applicationArgs, rawAppName, version, restartPolicy) =>
         val appName = serviceName(rawAppName)
         val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
+        val serviceResourceName =
+          deploymentType match {
+            case CanaryDeploymentType => appName
+            case BlueGreenDeploymentType => appNameVersion
+            case RollingDeploymentType => appName
+          }
 
         val labels = Map(
           "app" -> appName,
-          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
+          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map(
+            serviceNameLabel -> serviceResourceName))(system => Map(serviceNameLabel -> system))
 
         val podTemplate =
           PodTemplate.generate(

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -93,9 +93,13 @@ object PodTemplate {
             Seq(
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api",
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=$managementEndpointName",
-              s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName",
+              // https://github.com/akka/akka-management/blob/v0.20.0/cluster-bootstrap/src/main/resources/reference.conf
+              akkaClusterBootstrapSystemName match {
+                case Some(systemName) => s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$systemName"
+                case _ => s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName"
+              },
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas",
-              akkaClusterBootstrapSystemName.fold("-Dakka.discovery.kubernetes-api.pod-label-selector=app=%s")(systemName => s"-Dakka.discovery.kubernetes-api.pod-label-selector=actorSystemName=$systemName"),
+              "-Dakka.discovery.kubernetes-api.pod-label-selector=akka.lightbend.com/service-name=%s",
               s"${if (akkaClusterJoinExisting) "-Dakka.management.cluster.bootstrap.form-new-cluster=false" else ""}")
               .filter(_.nonEmpty)
               .mkString(" ")),

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -95,7 +95,7 @@ object PodTemplate {
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=$managementEndpointName",
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName",
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas",
-              akkaClusterBootstrapSystemName.fold("-Dakka.discovery.kubernetes-api.pod-label-selector=appName=%s")(systemName => s"-Dakka.discovery.kubernetes-api.pod-label-selector=actorSystemName=$systemName"),
+              akkaClusterBootstrapSystemName.fold("-Dakka.discovery.kubernetes-api.pod-label-selector=app=%s")(systemName => s"-Dakka.discovery.kubernetes-api.pod-label-selector=actorSystemName=$systemName"),
               s"${if (akkaClusterJoinExisting) "-Dakka.management.cluster.bootstrap.form-new-cluster=false" else ""}")
               .filter(_.nonEmpty)
               .mkString(" ")),
@@ -158,7 +158,7 @@ object PodTemplate {
    * If the akkaClusterJoinExisting flag is provided, these labels are removed from the pod template so that
    * it isn't used for bootstrap.
    */
-  private[kubernetes] val PodDiscoveryLabels = Set("appName", "actorSystemName")
+  private[kubernetes] val PodDiscoveryLabels = Set("app", "actorSystemName")
 
   /**
    * Represents possible values for imagePullPolicy field within the Kubernetes pod template.

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
@@ -69,8 +69,8 @@ object Service {
 
       val selector =
         deploymentType match {
-          case CanaryDeploymentType => Json("appName" -> appName.asJson)
-          case RollingDeploymentType => Json("appName" -> appName.asJson)
+          case CanaryDeploymentType => Json("app" -> appName.asJson)
+          case RollingDeploymentType => Json("app" -> appName.asJson)
           case BlueGreenDeploymentType => Json("appNameVersion" -> appNameVersion.asJson)
         }
 
@@ -85,7 +85,7 @@ object Service {
               "kind" -> "Service".asJson,
               "metadata" -> Json(
                 "labels" -> Json(
-                  "appName" -> appName.asJson),
+                  "app" -> appName.asJson),
                 "name" -> appName.asJson)
                 .deepmerge(
                   annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> serviceName(ns).asJson))),

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -34,6 +34,7 @@ import slogging.LazyLogging
 import Scalaz._
 
 package object kubernetes extends LazyLogging {
+  private[reactivecli] val serviceNameLabel = "akka.lightbend.com/service-name"
   private[reactivecli] val LivenessInitialDelaySeconds = 60
   private[reactivecli] val StatusPeriodSeconds = 10
 

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -114,7 +114,8 @@ object DeploymentJsonTest extends TestSuite {
               |    "name": "friendimpl-v3-2-1-snapshot",
               |    "labels": {
               |      "app": "friendimpl",
-              |      "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |      "appNameVersion": "friendimpl-v3-2-1-snapshot",
+              |      "akka.lightbend.com/service-name": "friendimpl"
               |    },
               |    "namespace": "chirper"
               |  },
@@ -129,7 +130,8 @@ object DeploymentJsonTest extends TestSuite {
               |      "metadata": {
               |        "labels": {
               |          "app": "friendimpl",
-              |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |          "appNameVersion": "friendimpl-v3-2-1-snapshot",
+              |          "akka.lightbend.com/service-name": "friendimpl"
               |        },
               |        "annotations": {
               |          "annotationKey0": "annotationValue0",
@@ -258,7 +260,8 @@ object DeploymentJsonTest extends TestSuite {
               |    "name": "friendimpl-v3-2-1-snapshot",
               |    "labels": {
               |      "app": "friendimpl",
-              |      "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |      "appNameVersion": "friendimpl-v3-2-1-snapshot",
+              |      "akka.lightbend.com/service-name": "friendimpl"
               |    },
               |    "namespace": "chirper"
               |  },
@@ -273,7 +276,8 @@ object DeploymentJsonTest extends TestSuite {
               |      "metadata": {
               |        "labels": {
               |          "app": "friendimpl",
-              |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |          "appNameVersion": "friendimpl-v3-2-1-snapshot",
+              |          "akka.lightbend.com/service-name": "friendimpl"
               |        },
               |        "annotations": {
               |          "annotationKey0": "annotationValue0",
@@ -351,7 +355,7 @@ object DeploymentJsonTest extends TestSuite {
               |              },
               |              {
               |                "name": "RP_JAVA_OPTS",
-              |                "value": "-Dconfig.resource=my-config.conf -Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1 -Dakka.discovery.kubernetes-api.pod-label-selector=app=%s"
+              |                "value": "-Dconfig.resource=my-config.conf -Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1 -Dakka.discovery.kubernetes-api.pod-label-selector=akka.lightbend.com/service-name=%s"
               |              },
               |              {
               |                "name": "RP_KUBERNETES_POD_IP",

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -113,7 +113,7 @@ object DeploymentJsonTest extends TestSuite {
               |  "metadata": {
               |    "name": "friendimpl-v3-2-1-snapshot",
               |    "labels": {
-              |      "appName": "friendimpl",
+              |      "app": "friendimpl",
               |      "appNameVersion": "friendimpl-v3-2-1-snapshot"
               |    },
               |    "namespace": "chirper"
@@ -128,7 +128,7 @@ object DeploymentJsonTest extends TestSuite {
               |    "template": {
               |      "metadata": {
               |        "labels": {
-              |          "appName": "friendimpl",
+              |          "app": "friendimpl",
               |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
               |        },
               |        "annotations": {
@@ -257,7 +257,7 @@ object DeploymentJsonTest extends TestSuite {
               |  "metadata": {
               |    "name": "friendimpl-v3-2-1-snapshot",
               |    "labels": {
-              |      "appName": "friendimpl",
+              |      "app": "friendimpl",
               |      "appNameVersion": "friendimpl-v3-2-1-snapshot"
               |    },
               |    "namespace": "chirper"
@@ -272,7 +272,7 @@ object DeploymentJsonTest extends TestSuite {
               |    "template": {
               |      "metadata": {
               |        "labels": {
-              |          "appName": "friendimpl",
+              |          "app": "friendimpl",
               |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
               |        },
               |        "annotations": {
@@ -351,7 +351,7 @@ object DeploymentJsonTest extends TestSuite {
               |              },
               |              {
               |                "name": "RP_JAVA_OPTS",
-              |                "value": "-Dconfig.resource=my-config.conf -Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1 -Dakka.discovery.kubernetes-api.pod-label-selector=appName=%s"
+              |                "value": "-Dconfig.resource=my-config.conf -Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1 -Dakka.discovery.kubernetes-api.pod-label-selector=app=%s"
               |              },
               |              {
               |                "name": "RP_KUBERNETES_POD_IP",

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
@@ -70,12 +70,14 @@ object JobJsonTest extends TestSuite {
           "name" -> jString("friendimpl-v3-2-1-snapshot"),
           "labels" -> jObjectFields(
             "app" -> jString("friendimpl"),
-            "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"))),
+            "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"),
+            "akka.lightbend.com/service-name" -> jString("friendimpl"))),
         "spec" -> jObjectFields(
           "template" -> jObjectFields(
             "metadata" -> jObjectFields(
               "labels" -> jObjectFields(
-                "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"))),
+                "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"),
+                "akka.lightbend.com/service-name" -> jString("friendimpl"))),
             "spec" -> jObjectFields(
               "restartPolicy" -> jString("OnFailure"),
               "containers" -> jArrayElements(

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
@@ -69,7 +69,7 @@ object JobJsonTest extends TestSuite {
         "metadata" -> jObjectFields(
           "name" -> jString("friendimpl-v3-2-1-snapshot"),
           "labels" -> jObjectFields(
-            "appName" -> jString("friendimpl"),
+            "app" -> jString("friendimpl"),
             "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"))),
         "spec" -> jObjectFields(
           "template" -> jObjectFields(

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
@@ -131,7 +131,7 @@ object KubernetesPackageTest extends TestSuite {
                   |  "metadata": {
                   |    "name": "my-app-v3-2-1-snapshot",
                   |    "labels": {
-                  |      "appName": "my-app",
+                  |      "app": "my-app",
                   |      "appNameVersion": "my-app-v3-2-1-snapshot"
                   |    },
                   |    "namespace": "chirper"
@@ -146,7 +146,7 @@ object KubernetesPackageTest extends TestSuite {
                   |    "template": {
                   |      "metadata": {
                   |        "labels": {
-                  |          "appName": "my-app",
+                  |          "app": "my-app",
                   |          "appNameVersion": "my-app-v3-2-1-snapshot"
                   |        }
                   |      },
@@ -259,7 +259,7 @@ object KubernetesPackageTest extends TestSuite {
                   |  "kind": "Service",
                   |  "metadata": {
                   |    "labels": {
-                  |      "appName": "my-app"
+                  |      "app": "my-app"
                   |    },
                   |    "name": "my-app",
                   |    "namespace": "chirper"
@@ -286,7 +286,7 @@ object KubernetesPackageTest extends TestSuite {
                   |      }
                   |    ],
                   |    "selector": {
-                  |      "appName": "my-app"
+                  |      "app": "my-app"
                   |    }
                   |  }
                   |}

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
@@ -132,7 +132,8 @@ object KubernetesPackageTest extends TestSuite {
                   |    "name": "my-app-v3-2-1-snapshot",
                   |    "labels": {
                   |      "app": "my-app",
-                  |      "appNameVersion": "my-app-v3-2-1-snapshot"
+                  |      "appNameVersion": "my-app-v3-2-1-snapshot",
+                  |      "akka.lightbend.com/service-name": "my-app"
                   |    },
                   |    "namespace": "chirper"
                   |  },
@@ -147,7 +148,8 @@ object KubernetesPackageTest extends TestSuite {
                   |      "metadata": {
                   |        "labels": {
                   |          "app": "my-app",
-                  |          "appNameVersion": "my-app-v3-2-1-snapshot"
+                  |          "appNameVersion": "my-app-v3-2-1-snapshot",
+                  |          "akka.lightbend.com/service-name": "my-app"
                   |        }
                   |      },
                   |      "spec": {

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
@@ -65,7 +65,7 @@ object ServiceJsonTest extends TestSuite {
             .get
             .payload
             .map { j =>
-              val result = (j.hcursor --\ "spec" --\ "selector" --\ "appName").focus
+              val result = (j.hcursor --\ "spec" --\ "selector" --\ "app").focus
               val expected = Some(jString("friendimpl"))
 
               assert(result == expected)
@@ -89,7 +89,7 @@ object ServiceJsonTest extends TestSuite {
             .get
             .get
             .payload
-            .map(j => assert((j.hcursor --\ "spec" --\ "selector" --\ "appName").focus.contains(jString("friendimpl"))))
+            .map(j => assert((j.hcursor --\ "spec" --\ "selector" --\ "app").focus.contains(jString("friendimpl"))))
         }
       }
 
@@ -113,7 +113,7 @@ object ServiceJsonTest extends TestSuite {
               |  "kind": "Service",
               |  "metadata": {
               |    "labels": {
-              |      "appName": "friendimpl"
+              |      "app": "friendimpl"
               |    },
               |    "name": "friendimpl",
               |    "namespace": "chirper"
@@ -128,7 +128,7 @@ object ServiceJsonTest extends TestSuite {
               |      }
               |    ],
               |    "selector": {
-              |      "appName": "friendimpl"
+              |      "app": "friendimpl"
               |    }
               |  }
               |}
@@ -145,7 +145,7 @@ object ServiceJsonTest extends TestSuite {
               |  "kind": "Service",
               |  "metadata": {
               |    "labels": {
-              |      "appName": "friendimpl"
+              |      "app": "friendimpl"
               |    },
               |    "name": "friendimpl",
               |    "namespace": "chirper"
@@ -163,7 +163,7 @@ object ServiceJsonTest extends TestSuite {
               |    ],
               |    "type": "NodePort",
               |    "selector": {
-              |      "appName": "friendimpl"
+              |      "app": "friendimpl"
               |    }
               |  }
               |}


### PR DESCRIPTION
Fixes #183
Ref https://github.com/akka/akka-management/issues/411

First, `appName` label is renamed to a more commonly used `app` label, aligning with standards and Akka Management docs. This will stay since `app` is used in different contexts other than Akka Cluster Bootstrap, for example `Service` resource uses label:

```yaml
  selector:
    app: "my-app"
``` 

For the purpose of Akka Cluster Bootstrap, however, a specialized label `akka.lightbend.com/service-name` is defined. This denotes the Akka Cluster to join when a pod comes up.

- The value of the this label will default to either the app name or the app version name depending on the deployment type.
- It can be overridden by user using `akkaClusterBootstrapSystemName` setting as described in https://developer.lightbend.com/docs/lightbend-orchestration/current/features/akka-cluster-bootstrap.html.
- Deployment pods are labeled with `"akka.lightbend.com/service-name": "friendimpl"` etc
- The label selector is overridden as `-Dakka.discovery.kubernetes-api.pod-label-selector=akka.lightbend.com/service-name=%s` (as opposed to using `app=%s`)
- The effective name is overridden as `-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl` etc.

/cc @lightbend/play-team 
