### PR TITLE
implement YAML generation for discovery-method=akka-dns

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -61,6 +61,20 @@ case object BlueGreenDeploymentType extends DeploymentType
 case object RollingDeploymentType extends DeploymentType
 
 /**
+ * Represents the discovery method during Akka Boostrap on Kubernetes.
+ */
+sealed trait DiscoveryMethod
+object DiscoveryMethod {
+  case object KubernetesApi extends DiscoveryMethod {
+    override def toString: String = "kubernetes-api"
+  }
+  case object AkkaDns extends DiscoveryMethod {
+    override def toString = "akka-dns"
+  }
+  def all = Seq(AkkaDns, KubernetesApi)
+}
+
+/**
  * Represents the input argument for `generate-deployment` command.
  */
 case class GenerateDeploymentArgs(
@@ -68,6 +82,7 @@ case class GenerateDeploymentArgs(
   akkaClusterJoinExisting: Boolean = false,
   akkaClusterSkipValidation: Boolean = false,
   deploymentType: DeploymentType = CanaryDeploymentType,
+  discoveryMethod: DiscoveryMethod = DiscoveryMethod.AkkaDns,
   dockerImages: Seq[String] = Seq.empty,
   name: Option[String] = None,
   version: Option[String] = None,

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -37,6 +37,14 @@ object InputArgs {
         throw new IllegalArgumentException(s"Invalid deployment type $v. Available: ${DeploymentType.All.mkString(", ")}")
     }
 
+  implicit val discoveryMethodRead: scopt.Read[DiscoveryMethod] =
+    scopt.Read.reads {
+      case v if v.toLowerCase == DiscoveryMethod.AkkaDns.toString => DiscoveryMethod.AkkaDns
+      case v if v.toLowerCase == DiscoveryMethod.KubernetesApi.toString => DiscoveryMethod.KubernetesApi
+      case v =>
+        throw new IllegalArgumentException(s"Invalid discovery method $v. Available: ${DiscoveryMethod.all.mkString(", ")}")
+    }
+
   implicit val logLevelsRead: scopt.Read[LogLevel] =
     scopt.Read.reads {
       case v if v.toLowerCase == "error" => LogLevel.ERROR
@@ -121,6 +129,11 @@ object InputArgs {
             .text(s"Sets the deployment type. Default: ${DeploymentType.Canary}; Available: ${DeploymentType.All.mkString(", ")}")
             .optional()
             .action(GenerateDeploymentArgs.set((t, args) => args.copy(deploymentType = t))),
+
+          opt[DiscoveryMethod]("discovery-method")
+            .text(s"Sets the discovery method. Default: ${DiscoveryMethod.AkkaDns}; Available: ${DiscoveryMethod.all.mkString(", ")}")
+            .optional()
+            .action(GenerateDeploymentArgs.set((t, args) => args.copy(discoveryMethod = t))),
 
           opt[String]("env") /* note: this argument will apply for other targets */
             .text("Sets an environment variable. Format: NAME=value")

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
@@ -47,6 +47,7 @@ object Deployment {
     noOfReplicas: Int,
     externalServices: Map[String, Seq[String]],
     deploymentType: DeploymentType,
+    discoveryMethod: DiscoveryMethod,
     jsonTransform: JsonTransform,
     akkaClusterJoinExisting: Boolean): ValidationNel[String, Deployment] =
 
@@ -80,6 +81,7 @@ object Deployment {
             RestartPolicy.Always, // The only valid RestartPolicy for Deployment
             externalServices,
             deploymentType,
+            discoveryMethod,
             akkaClusterJoinExisting,
             applicationArgs,
             appName,

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
@@ -58,7 +58,7 @@ object Deployment {
         val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
 
         val labels = Map(
-          "appName" -> appName,
+          "app" -> appName,
           "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
 
         val podTemplate =
@@ -87,7 +87,7 @@ object Deployment {
               (appNameVersion, Json("appNameVersion" -> appNameVersion.asJson))
 
             case RollingDeploymentType =>
-              (appName, Json("appName" -> appName.asJson))
+              (appName, Json("app" -> appName.asJson))
           }
 
         Deployment(

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Deployment.scala
@@ -57,9 +57,17 @@ object Deployment {
         val appName = serviceName(rawAppName)
         val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
 
+        val serviceResourceName =
+          deploymentType match {
+            case CanaryDeploymentType => appName
+            case BlueGreenDeploymentType => appNameVersion
+            case RollingDeploymentType => appName
+          }
+
         val labels = Map(
           "app" -> appName,
-          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
+          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map(
+            serviceNameLabel -> serviceResourceName))(system => Map(serviceNameLabel -> system))
 
         val podTemplate =
           PodTemplate.generate(

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
@@ -58,7 +58,7 @@ object Job {
         val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
 
         val labels = Map(
-          "appName" -> appName,
+          "app" -> appName,
           "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
 
         val podTemplate =

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
@@ -47,6 +47,7 @@ object Job {
     noOfReplicas: Int,
     externalServices: Map[String, Seq[String]],
     deploymentType: DeploymentType,
+    discoveryMethod: DiscoveryMethod,
     jsonTransform: JsonTransform,
     akkaClusterJoinExisting: Boolean): ValidationNel[String, Job] =
 
@@ -79,6 +80,7 @@ object Job {
             if (restartPolicy == RestartPolicy.Default) RestartPolicy.OnFailure else restartPolicy,
             externalServices,
             deploymentType,
+            discoveryMethod,
             akkaClusterJoinExisting,
             applicationArgs,
             appName,

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Job.scala
@@ -56,10 +56,17 @@ object Job {
       |@| restartPolicyValidation(restartPolicy)) { (applicationArgs, rawAppName, version, restartPolicy) =>
         val appName = serviceName(rawAppName)
         val appNameVersion = serviceName(s"$appName$VersionSeparator$version")
+        val serviceResourceName =
+          deploymentType match {
+            case CanaryDeploymentType => appName
+            case BlueGreenDeploymentType => appNameVersion
+            case RollingDeploymentType => appName
+          }
 
         val labels = Map(
           "app" -> appName,
-          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map.empty[String, String])(system => Map("actorSystemName" -> system))
+          "appNameVersion" -> appNameVersion) ++ annotations.akkaClusterBootstrapSystemName.fold(Map(
+            serviceNameLabel -> serviceResourceName))(system => Map(serviceNameLabel -> system))
 
         val podTemplate =
           PodTemplate.generate(

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -93,9 +93,13 @@ object PodTemplate {
             Seq(
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api",
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=$managementEndpointName",
-              s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName",
+              // https://github.com/akka/akka-management/blob/v0.20.0/cluster-bootstrap/src/main/resources/reference.conf
+              akkaClusterBootstrapSystemName match {
+                case Some(systemName) => s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$systemName"
+                case _ => s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName"
+              },
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas",
-              akkaClusterBootstrapSystemName.fold("-Dakka.discovery.kubernetes-api.pod-label-selector=app=%s")(systemName => s"-Dakka.discovery.kubernetes-api.pod-label-selector=actorSystemName=$systemName"),
+              "-Dakka.discovery.kubernetes-api.pod-label-selector=akka.lightbend.com/service-name=%s",
               s"${if (akkaClusterJoinExisting) "-Dakka.management.cluster.bootstrap.form-new-cluster=false" else ""}")
               .filter(_.nonEmpty)
               .mkString(" ")),

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -95,7 +95,7 @@ object PodTemplate {
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=$managementEndpointName",
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName",
               s"-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas",
-              akkaClusterBootstrapSystemName.fold("-Dakka.discovery.kubernetes-api.pod-label-selector=appName=%s")(systemName => s"-Dakka.discovery.kubernetes-api.pod-label-selector=actorSystemName=$systemName"),
+              akkaClusterBootstrapSystemName.fold("-Dakka.discovery.kubernetes-api.pod-label-selector=app=%s")(systemName => s"-Dakka.discovery.kubernetes-api.pod-label-selector=actorSystemName=$systemName"),
               s"${if (akkaClusterJoinExisting) "-Dakka.management.cluster.bootstrap.form-new-cluster=false" else ""}")
               .filter(_.nonEmpty)
               .mkString(" ")),
@@ -158,7 +158,7 @@ object PodTemplate {
    * If the akkaClusterJoinExisting flag is provided, these labels are removed from the pod template so that
    * it isn't used for bootstrap.
    */
-  private[kubernetes] val PodDiscoveryLabels = Set("appName", "actorSystemName")
+  private[kubernetes] val PodDiscoveryLabels = Set("app", "actorSystemName")
 
   /**
    * Represents possible values for imagePullPolicy field within the Kubernetes pod template.

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/Service.scala
@@ -69,8 +69,8 @@ object Service {
 
       val selector =
         deploymentType match {
-          case CanaryDeploymentType => Json("appName" -> appName.asJson)
-          case RollingDeploymentType => Json("appName" -> appName.asJson)
+          case CanaryDeploymentType => Json("app" -> appName.asJson)
+          case RollingDeploymentType => Json("app" -> appName.asJson)
           case BlueGreenDeploymentType => Json("appNameVersion" -> appNameVersion.asJson)
         }
 
@@ -85,7 +85,7 @@ object Service {
               "kind" -> "Service".asJson,
               "metadata" -> Json(
                 "labels" -> Json(
-                  "appName" -> appName.asJson),
+                  "app" -> appName.asJson),
                 "name" -> appName.asJson)
                 .deepmerge(
                   annotations.namespace.fold(jEmptyObject)(ns => Json("namespace" -> serviceName(ns).asJson))),

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -34,6 +34,7 @@ import slogging.LazyLogging
 import Scalaz._
 
 package object kubernetes extends LazyLogging {
+  private[reactivecli] val serviceNameLabel = "akka.lightbend.com/service-name"
   private[reactivecli] val LivenessInitialDelaySeconds = 60
   private[reactivecli] val StatusPeriodSeconds = 10
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/package.scala
@@ -91,6 +91,7 @@ package object kubernetes extends LazyLogging {
               kubernetesArgs.podControllerArgs.numberOfReplicas,
               generateDeploymentArgs.externalServices,
               generateDeploymentArgs.deploymentType,
+              generateDeploymentArgs.discoveryMethod,
               kubernetesArgs.transformPodControllers.fold(JsonTransform.noop)(JsonTransform.jq),
               generateDeploymentArgs.akkaClusterJoinExisting)
 
@@ -105,6 +106,7 @@ package object kubernetes extends LazyLogging {
               kubernetesArgs.podControllerArgs.numberOfReplicas,
               generateDeploymentArgs.externalServices,
               generateDeploymentArgs.deploymentType,
+              generateDeploymentArgs.discoveryMethod,
               kubernetesArgs.transformPodControllers.fold(JsonTransform.noop)(JsonTransform.jq),
               generateDeploymentArgs.akkaClusterJoinExisting)
         }
@@ -114,6 +116,7 @@ package object kubernetes extends LazyLogging {
         serviceApiVersion,
         kubernetesArgs.serviceArgs.clusterIp,
         generateDeploymentArgs.deploymentType,
+        generateDeploymentArgs.discoveryMethod,
         kubernetesArgs.transformServices.fold(JsonTransform.noop)(JsonTransform.jq),
         kubernetesArgs.serviceArgs.loadBalancerIp,
         kubernetesArgs.serviceArgs.serviceType)

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/annotations/AnnotationsTest.scala
@@ -121,6 +121,7 @@ object AnnotationsTest extends TestSuite {
           cpu = None,
           endpoints = Map.empty,
           managementEndpointName = None,
+          remotingEndpointName = None,
           secrets = Seq.empty,
           privileged = false,
           environmentVariables = Map.empty,
@@ -202,6 +203,7 @@ object AnnotationsTest extends TestSuite {
                 "ep2" -> TcpEndpoint(1, "ep2", 1234),
                 "ep3" -> UdpEndpoint(2, "ep3", 1234)),
               managementEndpointName = Some("management"),
+              remotingEndpointName = Some("remoting"),
               secrets = Seq.empty,
               annotations = Vector(
                 Annotation("annotationKey0", "annotationValue0"),
@@ -245,6 +247,7 @@ object AnnotationsTest extends TestSuite {
               cpu = Some(0.5),
               endpoints = Map.empty,
               managementEndpointName = None,
+              remotingEndpointName = None,
               secrets = Seq.empty,
               privileged = false,
               environmentVariables = Map(
@@ -272,6 +275,7 @@ object AnnotationsTest extends TestSuite {
               cpu = None,
               endpoints = Map.empty,
               managementEndpointName = None,
+              remotingEndpointName = None,
               secrets = Seq.empty,
               privileged = false,
               environmentVariables = Map.empty,
@@ -295,6 +299,7 @@ object AnnotationsTest extends TestSuite {
               cpu = None,
               endpoints = Map.empty,
               managementEndpointName = None,
+              remotingEndpointName = None,
               secrets = Seq.empty,
               privileged = false,
               environmentVariables = Map.empty,
@@ -318,6 +323,7 @@ object AnnotationsTest extends TestSuite {
               cpu = None,
               endpoints = Map.empty,
               managementEndpointName = None,
+              remotingEndpointName = None,
               secrets = Seq.empty,
               privileged = false,
               environmentVariables = Map.empty,
@@ -347,6 +353,7 @@ object AnnotationsTest extends TestSuite {
               endpoints = Map(
                 "ep2" -> TcpEndpoint(1, "ep2", 1234)),
               managementEndpointName = None,
+              remotingEndpointName = None,
               secrets = Seq.empty,
               privileged = false,
               environmentVariables = Map.empty,
@@ -374,6 +381,7 @@ object AnnotationsTest extends TestSuite {
               endpoints = Map(
                 "ep2" -> TcpEndpoint(1, "ep2", 1234)),
               managementEndpointName = None,
+              remotingEndpointName = None,
               secrets = Seq.empty,
               privileged = false,
               environmentVariables = Map.empty,

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -114,7 +114,8 @@ object DeploymentJsonTest extends TestSuite {
               |    "name": "friendimpl-v3-2-1-snapshot",
               |    "labels": {
               |      "app": "friendimpl",
-              |      "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |      "appNameVersion": "friendimpl-v3-2-1-snapshot",
+              |      "akka.lightbend.com/service-name": "friendimpl"
               |    },
               |    "namespace": "chirper"
               |  },
@@ -129,7 +130,8 @@ object DeploymentJsonTest extends TestSuite {
               |      "metadata": {
               |        "labels": {
               |          "app": "friendimpl",
-              |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |          "appNameVersion": "friendimpl-v3-2-1-snapshot",
+              |          "akka.lightbend.com/service-name": "friendimpl"
               |        },
               |        "annotations": {
               |          "annotationKey0": "annotationValue0",
@@ -258,7 +260,8 @@ object DeploymentJsonTest extends TestSuite {
               |    "name": "friendimpl-v3-2-1-snapshot",
               |    "labels": {
               |      "app": "friendimpl",
-              |      "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |      "appNameVersion": "friendimpl-v3-2-1-snapshot",
+              |      "akka.lightbend.com/service-name": "friendimpl"
               |    },
               |    "namespace": "chirper"
               |  },
@@ -273,7 +276,8 @@ object DeploymentJsonTest extends TestSuite {
               |      "metadata": {
               |        "labels": {
               |          "app": "friendimpl",
-              |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
+              |          "appNameVersion": "friendimpl-v3-2-1-snapshot",
+              |          "akka.lightbend.com/service-name": "friendimpl"
               |        },
               |        "annotations": {
               |          "annotationKey0": "annotationValue0",
@@ -351,7 +355,7 @@ object DeploymentJsonTest extends TestSuite {
               |              },
               |              {
               |                "name": "RP_JAVA_OPTS",
-              |                "value": "-Dconfig.resource=my-config.conf -Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1 -Dakka.discovery.kubernetes-api.pod-label-selector=app=%s"
+              |                "value": "-Dconfig.resource=my-config.conf -Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1 -Dakka.discovery.kubernetes-api.pod-label-selector=akka.lightbend.com/service-name=%s"
               |              },
               |              {
               |                "name": "RP_KUBERNETES_POD_IP",

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -113,7 +113,7 @@ object DeploymentJsonTest extends TestSuite {
               |  "metadata": {
               |    "name": "friendimpl-v3-2-1-snapshot",
               |    "labels": {
-              |      "appName": "friendimpl",
+              |      "app": "friendimpl",
               |      "appNameVersion": "friendimpl-v3-2-1-snapshot"
               |    },
               |    "namespace": "chirper"
@@ -128,7 +128,7 @@ object DeploymentJsonTest extends TestSuite {
               |    "template": {
               |      "metadata": {
               |        "labels": {
-              |          "appName": "friendimpl",
+              |          "app": "friendimpl",
               |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
               |        },
               |        "annotations": {
@@ -257,7 +257,7 @@ object DeploymentJsonTest extends TestSuite {
               |  "metadata": {
               |    "name": "friendimpl-v3-2-1-snapshot",
               |    "labels": {
-              |      "appName": "friendimpl",
+              |      "app": "friendimpl",
               |      "appNameVersion": "friendimpl-v3-2-1-snapshot"
               |    },
               |    "namespace": "chirper"
@@ -272,7 +272,7 @@ object DeploymentJsonTest extends TestSuite {
               |    "template": {
               |      "metadata": {
               |        "labels": {
-              |          "appName": "friendimpl",
+              |          "app": "friendimpl",
               |          "appNameVersion": "friendimpl-v3-2-1-snapshot"
               |        },
               |        "annotations": {
@@ -351,7 +351,7 @@ object DeploymentJsonTest extends TestSuite {
               |              },
               |              {
               |                "name": "RP_JAVA_OPTS",
-              |                "value": "-Dconfig.resource=my-config.conf -Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1 -Dakka.discovery.kubernetes-api.pod-label-selector=appName=%s"
+              |                "value": "-Dconfig.resource=my-config.conf -Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api -Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management -Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl -Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1 -Dakka.discovery.kubernetes-api.pod-label-selector=app=%s"
               |              },
               |              {
               |                "name": "RP_KUBERNETES_POD_IP",

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/IngressJsonTest.scala
@@ -46,6 +46,7 @@ object IngressJsonTest extends TestSuite {
             HttpIngress(Seq(80, 443), Seq("hello.com"), Seq.empty),
             HttpIngress(Seq(80, 443), Seq("hello.com", "world.io"), Seq(urlOne, urlTwo))))),
       managementEndpointName = None,
+      remotingEndpointName = None,
       secrets = Seq.empty,
       privileged = true,
       environmentVariables = Map(

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
@@ -18,7 +18,7 @@ package com.lightbend.rp.reactivecli.runtime.kubernetes
 
 import argonaut._
 import com.lightbend.rp.reactivecli.annotations.{ Annotations, LiteralEnvironmentVariable, Secret }
-import com.lightbend.rp.reactivecli.argparse.CanaryDeploymentType
+import com.lightbend.rp.reactivecli.argparse.{ CanaryDeploymentType, DiscoveryMethod }
 import com.lightbend.rp.reactivecli.json.JsonTransform
 import scala.collection.immutable.Seq
 import utest._
@@ -37,6 +37,7 @@ object JobJsonTest extends TestSuite {
     cpu = None,
     endpoints = Map.empty,
     managementEndpointName = None,
+    remotingEndpointName = None,
     secrets = Seq.empty,
     privileged = false,
     environmentVariables = Map.empty,
@@ -58,6 +59,7 @@ object JobJsonTest extends TestSuite {
           noOfReplicas = 1,
           Map.empty,
           CanaryDeploymentType,
+          DiscoveryMethod.AkkaDns,
           JsonTransform.noop,
           true)
 
@@ -112,6 +114,7 @@ object JobJsonTest extends TestSuite {
           noOfReplicas = 1,
           Map.empty,
           CanaryDeploymentType,
+          DiscoveryMethod.AkkaDns,
           JsonTransform.noop,
           true)
 

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
@@ -70,12 +70,14 @@ object JobJsonTest extends TestSuite {
           "name" -> jString("friendimpl-v3-2-1-snapshot"),
           "labels" -> jObjectFields(
             "app" -> jString("friendimpl"),
-            "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"))),
+            "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"),
+            "akka.lightbend.com/service-name" -> jString("friendimpl"))),
         "spec" -> jObjectFields(
           "template" -> jObjectFields(
             "metadata" -> jObjectFields(
               "labels" -> jObjectFields(
-                "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"))),
+                "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"),
+                "akka.lightbend.com/service-name" -> jString("friendimpl"))),
             "spec" -> jObjectFields(
               "restartPolicy" -> jString("OnFailure"),
               "containers" -> jArrayElements(

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
@@ -69,7 +69,7 @@ object JobJsonTest extends TestSuite {
         "metadata" -> jObjectFields(
           "name" -> jString("friendimpl-v3-2-1-snapshot"),
           "labels" -> jObjectFields(
-            "appName" -> jString("friendimpl"),
+            "app" -> jString("friendimpl"),
             "appNameVersion" -> jString("friendimpl-v3-2-1-snapshot"))),
         "spec" -> jObjectFields(
           "template" -> jObjectFields(

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
@@ -131,7 +131,7 @@ object KubernetesPackageTest extends TestSuite {
                   |  "metadata": {
                   |    "name": "my-app-v3-2-1-snapshot",
                   |    "labels": {
-                  |      "appName": "my-app",
+                  |      "app": "my-app",
                   |      "appNameVersion": "my-app-v3-2-1-snapshot"
                   |    },
                   |    "namespace": "chirper"
@@ -146,7 +146,7 @@ object KubernetesPackageTest extends TestSuite {
                   |    "template": {
                   |      "metadata": {
                   |        "labels": {
-                  |          "appName": "my-app",
+                  |          "app": "my-app",
                   |          "appNameVersion": "my-app-v3-2-1-snapshot"
                   |        }
                   |      },
@@ -259,7 +259,7 @@ object KubernetesPackageTest extends TestSuite {
                   |  "kind": "Service",
                   |  "metadata": {
                   |    "labels": {
-                  |      "appName": "my-app"
+                  |      "app": "my-app"
                   |    },
                   |    "name": "my-app",
                   |    "namespace": "chirper"
@@ -286,7 +286,7 @@ object KubernetesPackageTest extends TestSuite {
                   |      }
                   |    ],
                   |    "selector": {
-                  |      "appName": "my-app"
+                  |      "app": "my-app"
                   |    }
                   |  }
                   |}

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
@@ -132,7 +132,8 @@ object KubernetesPackageTest extends TestSuite {
                   |    "name": "my-app-v3-2-1-snapshot",
                   |    "labels": {
                   |      "app": "my-app",
-                  |      "appNameVersion": "my-app-v3-2-1-snapshot"
+                  |      "appNameVersion": "my-app-v3-2-1-snapshot",
+                  |      "akka.lightbend.com/service-name": "my-app"
                   |    },
                   |    "namespace": "chirper"
                   |  },
@@ -147,7 +148,8 @@ object KubernetesPackageTest extends TestSuite {
                   |      "metadata": {
                   |        "labels": {
                   |          "app": "my-app",
-                  |          "appNameVersion": "my-app-v3-2-1-snapshot"
+                  |          "appNameVersion": "my-app-v3-2-1-snapshot",
+                  |          "akka.lightbend.com/service-name": "my-app"
                   |        }
                   |      },
                   |      "spec": {

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/NamespaceJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/NamespaceJsonTest.scala
@@ -41,6 +41,7 @@ object NamespaceJsonTest extends TestSuite {
         cpu = None,
         endpoints = Map.empty,
         managementEndpointName = None,
+        remotingEndpointName = None,
         secrets = Seq.empty,
         privileged = false,
         environmentVariables = Map.empty,

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
@@ -65,7 +65,7 @@ object ServiceJsonTest extends TestSuite {
             .get
             .payload
             .map { j =>
-              val result = (j.hcursor --\ "spec" --\ "selector" --\ "appName").focus
+              val result = (j.hcursor --\ "spec" --\ "selector" --\ "app").focus
               val expected = Some(jString("friendimpl"))
 
               assert(result == expected)
@@ -89,7 +89,7 @@ object ServiceJsonTest extends TestSuite {
             .get
             .get
             .payload
-            .map(j => assert((j.hcursor --\ "spec" --\ "selector" --\ "appName").focus.contains(jString("friendimpl"))))
+            .map(j => assert((j.hcursor --\ "spec" --\ "selector" --\ "app").focus.contains(jString("friendimpl"))))
         }
       }
 
@@ -113,7 +113,7 @@ object ServiceJsonTest extends TestSuite {
               |  "kind": "Service",
               |  "metadata": {
               |    "labels": {
-              |      "appName": "friendimpl"
+              |      "app": "friendimpl"
               |    },
               |    "name": "friendimpl",
               |    "namespace": "chirper"
@@ -128,7 +128,7 @@ object ServiceJsonTest extends TestSuite {
               |      }
               |    ],
               |    "selector": {
-              |      "appName": "friendimpl"
+              |      "app": "friendimpl"
               |    }
               |  }
               |}
@@ -145,7 +145,7 @@ object ServiceJsonTest extends TestSuite {
               |  "kind": "Service",
               |  "metadata": {
               |    "labels": {
-              |      "appName": "friendimpl"
+              |      "app": "friendimpl"
               |    },
               |    "name": "friendimpl",
               |    "namespace": "chirper"
@@ -163,7 +163,7 @@ object ServiceJsonTest extends TestSuite {
               |    ],
               |    "type": "NodePort",
               |    "selector": {
-              |      "appName": "friendimpl"
+              |      "app": "friendimpl"
               |    }
               |  }
               |}

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariablesTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariablesTest.scala
@@ -43,6 +43,7 @@ object RpEnvironmentVariablesTest extends TestSuite {
               endpoints = Map(
                 "ep1" -> TcpEndpoint(0, "ep1", 1234)),
               managementEndpointName = None,
+              remotingEndpointName = None,
               secrets = Seq.empty,
               privileged = true,
               environmentVariables = Map(
@@ -91,6 +92,7 @@ object RpEnvironmentVariablesTest extends TestSuite {
               endpoints = Map(
                 "ep1" -> TcpEndpoint(0, "ep1", 1234)),
               managementEndpointName = None,
+              remotingEndpointName = None,
               secrets = Seq.empty,
               privileged = true,
               environmentVariables = Map(
@@ -141,6 +143,7 @@ object RpEnvironmentVariablesTest extends TestSuite {
               endpoints = Map(
                 "ep1" -> TcpEndpoint(0, "ep1", 1234)),
               managementEndpointName = Some("management"),
+              remotingEndpointName = Some("remoting"),
               secrets = Seq.empty,
               privileged = true,
               environmentVariables = Map(
@@ -191,6 +194,7 @@ object RpEnvironmentVariablesTest extends TestSuite {
               endpoints = Map(
                 "ep1" -> TcpEndpoint(0, "ep1", 1234)),
               managementEndpointName = None,
+              remotingEndpointName = None,
               secrets = Seq.empty,
               privileged = true,
               environmentVariables = Map(

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/Dependencies.scala
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/Dependencies.scala
@@ -1,0 +1,21 @@
+import sbt._
+
+object Dependencies {
+  val akkaVersion = "2.5.19"
+  val akkaManagementVersion = "0.20.0"
+
+  val akkaActor = "com.typesafe.akka" %% "akka-actor" % akkaVersion
+  val akkaCluster = "com.typesafe.akka" %% "akka-cluster" % akkaVersion
+  val akkaClusterSharding = "com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion
+  val akkaClusterTools = "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion
+  val akkaSlj4j = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
+
+  val akkaManagement = "com.lightbend.akka.management" %% "akka-management" % akkaManagementVersion
+  val akkaBootstrap = "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % akkaManagementVersion
+  val akkaDiscoveryDns = "com.lightbend.akka.discovery" %% "akka-discovery-dns" % akkaManagementVersion
+  val akkaClusterHttp = "com.lightbend.akka.management" %% "akka-management-cluster-http" % akkaManagementVersion
+
+  val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
+
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5" % Test
+}

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/build.properties
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=1.2.7
+

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/plugins.sbt
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % "1.7.0-M1")
+addSbtPlugin("com.lightbend.rp" % "sbt-deckhand" % "0.1.0")

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/src/main/resources/application.conf
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+akka {
+  loglevel = DEBUG
+}

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/src/main/scala/foo/ClusterApp.scala
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/src/main/scala/foo/ClusterApp.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package foo
+
+import akka.actor.{ Actor, ActorLogging, ActorSystem, PoisonPill, Props }
+import akka.cluster.ClusterEvent.ClusterDomainEvent
+import akka.cluster.singleton.{ ClusterSingletonManager, ClusterSingletonManagerSettings }
+import akka.cluster.{ Cluster, ClusterEvent }
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.stream.ActorMaterializer
+
+object ClusterApp {
+
+  def main(args: Array[String]): Unit = {
+
+    implicit val system = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+    implicit val executionContext = system.dispatcher
+
+    val cluster = Cluster(system)
+    system.log.info("Starting Akka Management")
+    system.log.info("something2")
+    // AkkaManagement(system).start()
+    // ClusterBootstrap(system).start()
+
+    system.actorOf(
+      ClusterSingletonManager.props(
+        Props[NoisySingleton],
+        PoisonPill,
+        ClusterSingletonManagerSettings(system)))
+    Cluster(system).subscribe(
+      system.actorOf(Props[ClusterWatcher]),
+      ClusterEvent.InitialStateAsEvents,
+      classOf[ClusterDomainEvent])
+
+    // add real app routes here
+    val routes =
+      path("hello") {
+        get {
+          complete(
+            HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Hello</h1>"))
+        }
+      }
+
+    Http().bindAndHandle(routes, "0.0.0.0", 8080)
+
+    system.log.info(
+      s"Server online at http://localhost:8080/\nPress RETURN to stop...")
+
+    cluster.registerOnMemberUp(() => {
+      system.log.info("Cluster member is up!")
+    })
+  }
+
+  class ClusterWatcher extends Actor with ActorLogging {
+    val cluster = Cluster(context.system)
+
+    override def receive = {
+      case msg ⇒ log.info(s"Cluster ${cluster.selfAddress} >>> " + msg)
+    }
+  }
+}

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/src/main/scala/foo/NoisySingleton.scala
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/src/main/scala/foo/NoisySingleton.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package foo
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+
+class NoisySingleton extends Actor with ActorLogging {
+
+  override def preStart(): Unit =
+    log.info("Noisy singleton started")
+
+  override def postStop(): Unit =
+    log.info("Noisy singleton stopped")
+
+  override def receive: Receive = {
+    case msg => log.info("Msg: {}", msg)
+  }
+}

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/test
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/test
@@ -1,0 +1,4 @@
+> Docker/publishLocal
+> generateYaml
+$exists target/temp.yaml
+> check


### PR DESCRIPTION
This PR is on top of https://github.com/lightbend/reactive-cli/pull/194

This generates the YAML for Akka Cluster Boostrap under Kubernetes using DNS as described in [Akka Management 0.20.0 documentation](https://developer.lightbend.com/docs/akka-management/current/bootstrap/kubernetes.html).

/cc @lightbend/play-team 
