### PR TITLE
Generate a dummy LoadBalancer service

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,23 @@
+### Minikube
+
+on a fresh terminal..
+
+```
+minikube delete
+minikube start
+eval $(minikube docker-env)
+kubectl config current-context
+sbt
+> integrationTest/scripted bootstrap-demo/dns-kubernetes
+```
+
+### OpenShift
+
+```
+oc new-project reactivelibtest1
+export OC_TOKEN=$(oc serviceaccounts get-token default)
+echo "$OC_TOKEN" | docker login -u unused --password-stdin docker-registry-default.centralpark.lightbend.com
+sbt -Ddeckhand.openshift
+
+> integrationTest/scripted bootstrap-demo/dns-kubernetes
+```

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/ServiceJsonTest.scala
@@ -147,6 +147,34 @@ object ServiceJsonTest extends TestSuite {
               |  }
               |}
             """.stripMargin.parse.right.get
+          val dummyJson =
+            """
+              |{
+              |  "apiVersion": "v1",
+              |  "kind": "Service",
+              |  "metadata": {
+              |    "labels": {
+              |      "app": "friendimpl"
+              |    },
+              |    "name": "friendimpl-external",
+              |    "namespace": "chirper"
+              |  },
+              |  "spec": {
+              |    "ports": [
+              |      {
+              |        "name": "dummy",
+              |        "port": 70,
+              |        "protocol": "TCP",
+              |        "targetPort": 70
+              |      }
+              |    ],
+              |    "selector": {
+              |      "app": "friendimpl"
+              |    },
+              |    "type": "LoadBalancer"
+              |  }
+              |}
+            """.stripMargin.parse.right.get
           val serviceJson =
             """
               |{
@@ -174,8 +202,11 @@ object ServiceJsonTest extends TestSuite {
               |  }
               |}
             """.stripMargin.parse.right.get
+
+          assert(generatedJson.size == 3)
           assert(generatedJson == List(
             Service("friendimpl-internal", headlessJson, JsonTransform.noop),
+            Service("friendimpl-external", dummyJson, JsonTransform.noop),
             Service("friendimpl", serviceJson, JsonTransform.noop)))
 
         }

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-api/build.sbt
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-api/build.sbt
@@ -35,8 +35,8 @@ lazy val root = (project in file("."))
       logback,
       scalaTest
     ),
-    enableAkkaClusterBootstrap := true,
-    akkaClusterBootstrapSystemName := "hoboken1",
+    rpEnableAkkaClusterBootstrap := true,
+    rpAkkaClusterBootstrapSystemName := "hoboken1",
 
     // run nativeLink in the host build first
     generateYaml := {
@@ -75,8 +75,6 @@ lazy val root = (project in file("."))
               "namespace"       -> namespace
             ))
         } else {
-          // work around: /rp-start: line 60: /opt/docker/bin/bootstrap-kapi-demo: Permission denied
-          kubectl.command(s"adm policy add-scc-to-user anyuid system:serviceaccount:$namespace:default")
           kubectl.command(s"policy add-role-to-user system:image-builder system:serviceaccount:$namespace:default")
           kubectl.apply(Deckhand.mustache(yamlDir / "rbac.mustache"),
             Map(

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-api/project/Dependencies.scala
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-api/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val akkaVersion = "2.5.19"
+  val akkaVersion = "2.5.20"
   val akkaManagementVersion = "0.20.0"
 
   val akkaActor = "com.typesafe.akka" %% "akka-actor" % akkaVersion

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-api/project/plugins.sbt
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-api/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % "1.7.0-M1")
+addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % "1.7.0")
 addSbtPlugin("com.lightbend.rp" % "sbt-deckhand" % "0.1.0")

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/Dependencies.scala
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val akkaVersion = "2.5.19"
+  val akkaVersion = "2.5.20"
   val akkaManagementVersion = "0.20.0"
 
   val akkaActor = "com.typesafe.akka" %% "akka-actor" % akkaVersion

--- a/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/plugins.sbt
+++ b/integration-test/src/sbt-test/bootstrap-demo/kubernetes-dns/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % "1.7.0-M1")
+addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % "1.7.0")
 addSbtPlugin("com.lightbend.rp" % "sbt-deckhand" % "0.1.0")


### PR DESCRIPTION
Fixes https://github.com/lightbend/reactive-lib/issues/120

During Akka Cluster Boostrap using DNS, the self reference using IP address must
match up with the replicas we find via DNS.
The SRV record returned by the headless service is in the form of `auto-generated-name.my-svc.my-namespace.svc.cluster.local`.
https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#srv-records

Under some circumstances DNS also returns A record for the pods in the form of `pod-ip-address.my-namespace.pod.cluster.local`,
which we require to correctly figure out the lowest IP address (and to identify self node).
For reasons yet to be confirmed, service type `ClusterIP` (default) doesn't always work, but `LoadBalancer` works.
This means that the service will expose the service externally "using a cloud provider’s load balancer."
https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types

To workaround the issue, this PR creates a dummy service that exposes port 70 for Gopher.

/cc @lightbend/play-team 