### PR TITLE
-Dplay.server.pidfile.path=/dev/null, again

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/PodTemplate.scala
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp.reactivecli.runtime.kubernetes
+package com.lightbend.rp.reactivecli.runtime
+package kubernetes
 
 import argonaut._
 import com.lightbend.rp.reactivecli.annotations.kubernetes.{ ConfigMapEnvironmentVariable, FieldRefEnvironmentVariable, SecretKeyRefEnvironmentVariable }
@@ -56,6 +57,7 @@ object PodTemplate {
         appNameEnvs(annotations.appName),
         annotations.version.fold(Map.empty[String, EnvironmentVariable])(versionEnvs),
         appTypeEnvs(annotations.appType, annotations.modules),
+        Map("RP_JAVA_OPTS" -> LiteralEnvironmentVariable(playPidDevNull)),
         configEnvs(annotations.configResource),
         akkaClusterEnvs(
           annotations.appName,
@@ -116,8 +118,7 @@ object PodTemplate {
             }) ++
               List(
                 s"-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas",
-                s"${if (akkaClusterJoinExisting) "-Dakka.management.cluster.bootstrap.form-new-cluster=false" else ""}",
-                s"-Dplay.server.pidfile.path=/dev/null"))
+                s"${if (akkaClusterJoinExisting) "-Dakka.management.cluster.bootstrap.form-new-cluster=false" else ""}"))
               .filter(_.nonEmpty)
               .mkString(" ")),
           "RP_DYN_JAVA_OPTS" -> LiteralEnvironmentVariable(

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariables.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariables.scala
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-package com.lightbend.rp.reactivecli.runtime.marathon
+package com.lightbend.rp.reactivecli.runtime
+package marathon
 
 import com.lightbend.rp.reactivecli.annotations._
 import scala.collection.immutable.Seq
@@ -37,6 +38,7 @@ object RpEnvironmentVariables {
       annotations.version.fold(Map.empty[String, String])(versionEnvs),
       appTypeEnvs(annotations.appType, annotations.modules),
       configEnvs(annotations.configResource),
+      Map("RP_JAVA_OPTS" -> playPidDevNull),
       endpointEnvs(annotations.endpoints),
       akkaClusterEnvs(annotations.modules, annotations.namespace, serviceResourceName, annotations.managementEndpointName.getOrElse(legacyAkkaManagementPortName), noOfReplicas, annotations.akkaClusterBootstrapSystemName, akkaClusterJoinExisting),
       externalServicesEnvs(annotations.modules, externalServices))
@@ -69,8 +71,7 @@ object RpEnvironmentVariables {
           s"-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=$serviceResourceName",
           s"-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=$noOfReplicas",
           akkaClusterBootstrapSystemName.fold("-Dakka.discovery.marathon-api.app-label-query=APP_NAME==%s")(systemName => s"-Dakka.discovery.marathon-api.app-label-query=ACTOR_SYSTEM_NAME==$systemName"),
-          s"${if (akkaClusterJoinExisting) "-Dakka.management.cluster.bootstrap.form-new-cluster=false" else ""}",
-          s"-Dplay.server.pidfile.path=/dev/null")
+          s"${if (akkaClusterJoinExisting) "-Dakka.management.cluster.bootstrap.form-new-cluster=false" else ""}")
           .filter(_.nonEmpty)
           .mkString(" "))
 

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/package.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/runtime/package.scala
@@ -20,6 +20,7 @@ package object runtime {
   private[reactivecli] val AkkaClusterMinimumReplicas = 2
   private[reactivecli] val ReadyCheckUrl = "/platform-tooling/ready"
   private[reactivecli] val HealthCheckUrl = "/platform-tooling/healthy"
+  private[reactivecli] val playPidDevNull = "-Dplay.server.pidfile.path=/dev/null"
 
   def pathDepthAndLength(path: String): (Int, Int) = {
     val depth = path.split('/').length

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/DeploymentJsonTest.scala
@@ -192,7 +192,7 @@ object DeploymentJsonTest extends TestSuite {
               |              },
               |              {
               |                "name": "RP_JAVA_OPTS",
-              |                "value": "-Dconfig.resource=my-config.conf"
+              |                "value": "-Dplay.server.pidfile.path=/dev/null -Dconfig.resource=my-config.conf"
               |              },
               |              {
               |                "name": "RP_KUBERNETES_POD_IP",
@@ -422,13 +422,13 @@ object DeploymentJsonTest extends TestSuite {
               |                "name": "RP_JAVA_OPTS",
               |                "value": """".stripMargin +
               List(
+                "-Dplay.server.pidfile.path=/dev/null",
                 "-Dconfig.resource=my-config.conf",
                 "-Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=kubernetes-api",
                 "-Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management",
                 "-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl",
                 "-Dakka.discovery.kubernetes-api.pod-label-selector=akka.lightbend.com/service-name=%s",
-                "-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1",
-                "-Dplay.server.pidfile.path=/dev/null").mkString(" ") +
+                "-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=1").mkString(" ") +
                 """"
               |              },
               |              {

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/JobJsonTest.scala
@@ -93,6 +93,7 @@ object JobJsonTest extends TestSuite {
                     jObjectFields("name" -> jString("RP_APP_NAME"), "value" -> jString("friendimpl")),
                     jObjectFields("name" -> jString("RP_APP_TYPE"), "value" -> jString("basic")),
                     jObjectFields("name" -> jString("RP_APP_VERSION"), "value" -> jString("3.2.1-SNAPSHOT")),
+                    jObjectFields("name" -> jString("RP_JAVA_OPTS"), "value" -> jString("-Dplay.server.pidfile.path=/dev/null")),
                     jObjectFields("name" -> jString("RP_KUBERNETES_POD_IP"), "valueFrom" -> jObjectFields("fieldRef" -> jObjectFields("fieldPath" -> jString("status.podIP")))),
                     jObjectFields("name" -> jString("RP_KUBERNETES_POD_NAME"), "valueFrom" -> jObjectFields("fieldRef" -> jObjectFields("fieldPath" -> jString("metadata.name")))),
                     jObjectFields("name" -> jString("RP_NAMESPACE"), "valueFrom" -> jObjectFields("fieldRef" -> jObjectFields("fieldPath" -> jString("metadata.namespace")))),

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/kubernetes/KubernetesPackageTest.scala
@@ -189,6 +189,10 @@ object KubernetesPackageTest extends TestSuite {
                   |                "value": "3.2.1-SNAPSHOT"
                   |              },
                   |              {
+                  |                "name": "RP_JAVA_OPTS",
+                  |                "value": "-Dplay.server.pidfile.path=/dev/null"
+                  |              },
+                  |              {
                   |                "name": "RP_KUBERNETES_POD_IP",
                   |                "valueFrom": {
                   |                  "fieldRef": {
@@ -513,6 +517,10 @@ object KubernetesPackageTest extends TestSuite {
                   |              {
                   |                "name": "RP_APP_VERSION",
                   |                "value": "3.2.1-SNAPSHOT"
+                  |              },
+                  |              {
+                  |                "name": "RP_JAVA_OPTS",
+                  |                "value": "-Dplay.server.pidfile.path=/dev/null"
                   |              },
                   |              {
                   |                "name": "RP_KUBERNETES_POD_IP",

--- a/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariablesTest.scala
+++ b/cli/shared/src/test/scala/com/lightbend/rp/reactivecli/runtime/marathon/RpEnvironmentVariablesTest.scala
@@ -66,6 +66,7 @@ object RpEnvironmentVariablesTest extends TestSuite {
           "RP_ENDPOINTS" -> "EP1",
           "RP_APP_VERSION" -> "3.2.1-SNAPSHOT",
           "RP_PLATFORM" -> "mesos",
+          "RP_JAVA_OPTS" -> "-Dplay.server.pidfile.path=/dev/null",
           "RP_ENDPOINT_EP1_PORT" -> "$PORT_EP",
           "RP_APP_NAME" -> "friendimpl",
           "RP_ENDPOINT_0_PORT" -> "$PORT_EP",
@@ -114,12 +115,12 @@ object RpEnvironmentVariablesTest extends TestSuite {
           "RP_ENDPOINT_0_BIND_PORT" -> "$PORT_EP",
           "RP_ENDPOINTS" -> "EP1", "RP_APP_VERSION" -> "3.2.1-SNAPSHOT",
           "RP_JAVA_OPTS" -> List(
+            "-Dplay.server.pidfile.path=/dev/null",
             "-Dakka.management.cluster.bootstrap.contact-point-discovery.discovery-method=marathon-api",
             "-Dakka.management.cluster.bootstrap.contact-point-discovery.port-name=management",
             "-Dakka.management.cluster.bootstrap.contact-point-discovery.effective-name=friendimpl",
             "-Dakka.management.cluster.bootstrap.contact-point-discovery.required-contact-point-nr=3",
-            "-Dakka.discovery.marathon-api.app-label-query=APP_NAME==%s",
-            "-Dplay.server.pidfile.path=/dev/null").mkString(" "),
+            "-Dakka.discovery.marathon-api.app-label-query=APP_NAME==%s").mkString(" "),
           "RP_PLATFORM" -> "mesos",
           "RP_ENDPOINT_EP1_PORT" -> "$PORT_EP",
           "RP_MODULES" -> "akka-cluster-bootstrapping",
@@ -183,6 +184,7 @@ object RpEnvironmentVariablesTest extends TestSuite {
           "RP_ENDPOINT_EP1_BIND_HOST" -> "0.0.0.0",
           "RP_MODULES" -> "service-discovery",
           "RP_JAVA_OPTS" -> List(
+            "-Dplay.server.pidfile.path=/dev/null",
             "-Dcom.lightbend.platform-tooling.service-discovery.external-service-addresses.chirpservice.0=_chirpservice._tcp.marathon.mesos",
             "-Dcom.lightbend.platform-tooling.service-discovery.external-service-addresses.chirpservice.1=_chirpservice._udp.marathon.mesos",
             "-Dcom.lightbend.platform-tooling.service-discovery.external-service-addresses.friendservice.0=_friendservice._tcp.marathon.mesos").mkString(" "))


### PR DESCRIPTION
Ref https://github.com/lightbend/sbt-reactive-app/issues/177

https://github.com/lightbend/reactive-cli/pull/197 added `-Dplay.server.pidfile.path=/dev/null`, but only when Akka Clustering was enabled. This adds that for all cases.

/cc @lightbend/play-team 
