### PR TITLE
Default to registry-use-local

### DIFF
--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/CommandArgs.scala
@@ -29,7 +29,7 @@ object VersionArgs extends CommandArgs
 object GenerateDeploymentArgs {
   val DockerRegistryUseHttpsDefault = true
   val DockerRegistryValidateTlsDefault = true
-  val DockerRegistryUseLocalDefault = false
+  val DockerRegistryUseLocalDefault = true
 
   /**
    * Convenience method to set the [[GenerateDeploymentArgs]] values when parsing the complete user input.

--- a/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
+++ b/cli/shared/src/main/scala/com/lightbend/rp/reactivecli/argparse/InputArgs.scala
@@ -309,6 +309,11 @@ object InputArgs {
             .optional()
             .action(GenerateDeploymentArgs.set((_, c) => c.copy(registryUseLocal = true))),
 
+          opt[Unit]("registry-disable-local") /* note: this argument will apply for other targets */
+            .text("Disables the local docker registry before the remote registry.")
+            .optional()
+            .action(GenerateDeploymentArgs.set((_, c) => c.copy(registryUseLocal = false))),
+
           opt[String]("service-api-version")
             .text(s"Sets the Service API version. Default: ${printFuture(KubernetesArgs.DefaultServiceApiVersion)}")
             .optional()


### PR DESCRIPTION
Fixes #202

During rpDeploy the Docker image is pushed locally, so registry-use-local should be enabled by default.

/cc @lightbend/play-team 
